### PR TITLE
Fix local AWS_PROFILE configuration that assume role with terraform

### DIFF
--- a/cli/run_config.go
+++ b/cli/run_config.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
@@ -29,7 +30,7 @@ func importFiles(terragruntOptions *options.TerragruntOptions, importers []confi
 		}
 
 		if importer.Source != "" {
-			sourceFolder, err = util.GetSource(importer.Source, terragruntOptions.TerraformPath)
+			sourceFolder, err = util.GetSource(importer.Source, terragruntOptions.TerraformPath, terragruntOptions.EnvironmentVariables()...)
 			if err != nil {
 				return err
 			}
@@ -155,4 +156,16 @@ func getModulesFolders(terragruntOptions *options.TerragruntOptions) ([]string, 
 		keys = append(keys, key)
 	}
 	return keys, nil
+}
+
+func setRoleEnvironmentVariables(terragruntOptions *options.TerragruntOptions, roleArn string) error {
+	roleVars, err := aws_helper.AssumeRoleEnvironmentVariables(roleArn, "terragrunt")
+	if err != nil {
+		return err
+	}
+
+	for key, value := range roleVars {
+		terragruntOptions.Env[key] = value
+	}
+	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -317,7 +317,7 @@ func ParseConfigFile(terragruntOptions *options.TerragruntOptions, include Inclu
 		if include.Path == "" {
 			include.Path = DefaultTerragruntConfigPath
 		}
-		include.Path, configString, err = util.ReadFileAsStringFromSource(include.Source, include.Path, terragruntOptions.TerraformPath)
+		include.Path, configString, err = util.ReadFileAsStringFromSource(include.Source, include.Path, terragruntOptions.TerraformPath, terragruntOptions.EnvironmentVariables()...)
 	}
 	if err != nil {
 		return nil, err

--- a/util/file.go
+++ b/util/file.go
@@ -134,8 +134,8 @@ func ReadFileAsString(path string) (string, error) {
 // ReadFileAsStringFromSource returns the contents of the file at the given path
 // from an external source (github, s3, etc.) as a string
 // It uses terraform to execute its command
-func ReadFileAsStringFromSource(source, path string, terraform string) (localFile, content string, err error) {
-	cacheDir, err := GetSource(source, terraform)
+func ReadFileAsStringFromSource(source, path string, terraform string, env ...string) (localFile, content string, err error) {
+	cacheDir, err := GetSource(source, terraform, env...)
 	if err != nil {
 		return "", "", err
 	}
@@ -148,7 +148,7 @@ func ReadFileAsStringFromSource(source, path string, terraform string) (localFil
 // GetSource gets the content of the source in a temporary folder and returns
 // the local path. The function manages a cache to avoid multiple remote calls
 // if the content has not changed
-func GetSource(source string, terraform string) (string, error) {
+func GetSource(source string, terraform string, env ...string) (string, error) {
 	path, err := aws_helper.ConvertS3Path(source)
 	if err != nil {
 		return "", err
@@ -174,6 +174,7 @@ func GetSource(source string, terraform string) (string, error) {
 			cmd.Stdin = os.Stdin
 			var out bytes.Buffer
 			cmd.Stdout, cmd.Stderr = &out, &out
+			cmd.Env = env
 			err = cmd.Run()
 			if err != nil {
 				log.Error(out.String())


### PR DESCRIPTION
Event without assume role, terraform is not able to support AWS credentials defined through AWS_PROFILE that refers to an assume role.

To solve it, we export the corresponding AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID and AWS_SESSION_TOKEN environment variables before calling any terraform operations.