### PR TITLE
Add print-doc option to get the current context documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.8.x
+- 1.9.x
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -991,10 +991,13 @@ the terraform remote state has been configured.
 ```hcl
 terragrunt = {
   extra_command "name" {
-    commands  = [list of commands]  # optional (default use name as the command)
-    os        = [list of os]        # optional (default run on all os, os name are those supported by go, i.e. linux, darwin, windows)
-    use_state = true or false       # optional (default = true)
-    act_as    = "command"           # optional (default = empty, instructs to consider this extra command and its aliases as another command regarding extra_parameters evaluation)
+    description = ""                  # Description of the extra command action
+    command     = ""                  # optional (default use name as the command, actual command to use instead of name)
+    commands    = [list of commands]  # optional (list of other commands that should be included and are having the same behavior)
+    aliases     = [list of alias]     # optional (list of alias to ccommand or name or first item of commands)
+    os          = [list of os]        # optional (default run on all os, os name are those supported by go, i.e. linux, darwin, windows)
+    use_state   = true or false       # optional (default = true)
+    act_as      = "command"           # optional (default = empty, instructs to consider this extra command and its aliases as another command regarding extra_parameters evaluation)
   }
 }
 ```
@@ -1040,6 +1043,7 @@ It is possible to override hooks defined in a parent configuration by specifying
 ```hcl
 terragrunt = {
   pre_hooks|post_hooks "name" {
+    description      = ""                             # Description of the hook
     command          = "command"                      # shell command to execute
     on_commands      = [list of terraform commands]   # optional, default run on all terraform command
     os               = [list of os]                   # optional, default run on all os, os name are those supported by go, i.e. linux, darwin, windows
@@ -1080,8 +1084,8 @@ When terragrunt execute, it creates a temporary folder containing the source of 
 ```hcl
 terragrunt = {
   import_files "name" {
-    source              = "path"                        # Specify the source of the copy (support any [module
-sources](https://www.terraform.io/docs/modules/sources.html).))
+    description         = ""                            # Description of the import files action
+    source              = "path"                        # Specify the source of the copy (currently only support [S3 sources](https://www.terraform.io/docs/modules/sources.html).))
     files               = ["*"]                         # Optional, copy all files matching one of the pattern
     copy_and_rename     = []                            # Optional, specific rule to copy file from the source and rename it in the target
     required            = false                         # Optional, generate an error if there is no matching file

--- a/README.md
+++ b/README.md
@@ -998,6 +998,7 @@ terragrunt = {
     os          = [list of os]        # optional (default run on all os, os name are those supported by go, i.e. linux, darwin, windows)
     use_state   = true or false       # optional (default = true)
     act_as      = "command"           # optional (default = empty, instructs to consider this extra command and its aliases as another command regarding extra_parameters evaluation)
+    version     = ""                  # optional (argument to get the version of the command, if many command are defined, they must all support the same argument to get the version)
   }
 }
 ```

--- a/aws_helper/config.go
+++ b/aws_helper/config.go
@@ -29,6 +29,10 @@ func CreateAwsSession(awsRegion, awsProfile string) (*session.Session, error) {
 	}
 	if awsRegion != "" {
 		options.Config = aws.Config{Region: aws.String(awsRegion)}
+		if os.Getenv("AWS_REGION") == "" {
+			// If the default region is not set, we retain it
+			os.Setenv("AWS_REGION", awsRegion)
+		}
 	}
 	session, err := session.NewSessionWithOptions(options)
 

--- a/aws_helper/s3.go
+++ b/aws_helper/s3.go
@@ -35,7 +35,7 @@ func ConvertS3Path(path string) (string, error) {
 
 	region := ""
 	if answer.LocationConstraint != nil {
-		region = "-" + *answer.LocationConstraint
+		region = *answer.LocationConstraint
 	}
 
 	return formatS3Path(parts[0], region, parts[1:]...), nil
@@ -46,9 +46,11 @@ func formatS3Path(bucket, region string, parts ...string) string {
 	if key != "" {
 		key = "/" + key
 	}
-	if region == "-us-east-1" {
+	if region != "" && region != "us-east-1" {
 		// us-east-1 is considered as the default storage for S3, it is not necessary to specify it
 		// In fact, that caused a bug with terraform 0.10.3 and up (see https://github.com/hashicorp/terraform/issues/16442#issuecomment-339379748)
+		region = "-" + region
+	} else {
 		region = ""
 	}
 	return fmt.Sprintf("%s.s3%s.amazonaws.com%s", bucket, region, key)
@@ -60,13 +62,13 @@ func GetBucketObjectInfoFromURL(url string) (*BucketInfo, error) {
 		s3Patterns = []*regexp.Regexp{
 			regexp.MustCompile(`^https?://(?P<bucket>[^/\.]+?).s3.amazonaws.com(?:/(?P<key>.*))?$`),
 			regexp.MustCompile(`^https?://(?P<bucket>[^/\.]+?).s3-(?P<region>.*?).amazonaws.com(?:/(?P<key>.*))?$`),
-			regexp.MustCompile(`^https?://s3.amazonaws.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
-			regexp.MustCompile(`^https?://s3-(?P<region>.*?).amazonaws.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
+			regexp.MustCompile(`^(s3::)?https?://s3.amazonaws.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
+			regexp.MustCompile(`^(s3::)?https?://s3-(?P<region>.*?).amazonaws.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
 		}
 	}
 
 	convertedURL, _ := ConvertS3Path(url)
-	if !strings.HasPrefix(convertedURL, "http") {
+	if !strings.HasPrefix(convertedURL, "http") && !strings.HasPrefix(convertedURL, "s3::") {
 		convertedURL = "https://" + convertedURL
 	}
 
@@ -96,6 +98,11 @@ type BucketInfo struct {
 	BucketName string
 	Region     string
 	Key        string
+}
+
+// Path returns a valid path from a bucket object
+func (b *BucketInfo) String() string {
+	return formatS3Path(b.BucketName, b.Region, b.Key)
 }
 
 type bucketStatus struct {
@@ -138,26 +145,27 @@ func SaveS3Status(url, folder string) (err error) {
 
 // CheckS3Status compares the saved status with the current version of the bucket folder
 // returns true if the objects has not changed
-func CheckS3Status(folder string) (bool, error) {
+func CheckS3Status(folder string) error {
 	content, err := ioutil.ReadFile(filepath.Join(folder, cacheFile))
 	if err != nil {
-		return false, fmt.Errorf("Error reading file %s/%s: %v", folder, cacheFile, err)
+		return err
 	}
 
 	var status bucketStatus
 	err = json.Unmarshal(content, &status)
-	fmt.Println("status =", status, err)
 	if err != nil {
-		return false, fmt.Errorf("Content of %s/%s is not valid JSON %v", folder, cacheFile, err)
+		return fmt.Errorf("Content of %s/%s (%s) is not valid JSON: %v", folder, cacheFile, content, err)
 	}
 
 	s3Status, err := getS3Status(status.BucketInfo)
-	fmt.Println("s3Status =", status, err)
 	if err != nil {
-		return false, fmt.Errorf("Error while reading %v: %v", status.BucketInfo, err)
+		return fmt.Errorf("Error while reading %s: %v", status.BucketInfo, err)
 	}
 
-	return reflect.DeepEqual(status, *s3Status), nil
+	if !reflect.DeepEqual(status, *s3Status) {
+		return fmt.Errorf("Checksum changed for %s", status.BucketInfo)
+	}
+	return nil
 }
 
 const cacheFile = ".terragrunt.cache"

--- a/aws_helper/s3_test.go
+++ b/aws_helper/s3_test.go
@@ -17,6 +17,7 @@ func TestConvertS3Path(t *testing.T) {
 	}{
 		{"Non S3 path", args{"/folder/test"}, "/folder/test", false},
 		{"Non available S3", args{"s3://bucket/test"}, "bucket.s3.amazonaws.com/test", true},
+		{"Non available S3", args{"s3://bucket/test"}, "bucket.s3.amazonaws.com/test", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -52,6 +53,7 @@ func TestGetBucketObjectInfoFromURL(t *testing.T) {
 		{"https://bucket.s3-us-east-1.amazonaws.com", &BucketInfo{"bucket", "us-east-1", ""}, false},
 		{"https://bucket.s3-us-west-2.amazonaws.com/key", &BucketInfo{"bucket", "us-west-2", "key"}, false},
 		{"https://s3-us-east-2.amazonaws.com/bucket", &BucketInfo{"bucket", "us-east-2", ""}, false},
+		{"s3::https://s3-us-east-2.amazonaws.com/bucket", &BucketInfo{"bucket", "us-east-2", ""}, false},
 	}
 	for _, tt := range tests {
 		t.Run(" ("+tt.url+")", func(t *testing.T) {

--- a/cli/args.go
+++ b/cli/args.go
@@ -101,6 +101,7 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 
 	level, err := util.InitLogging(loggingLevel, logging.NOTICE, !util.ListContainsElement(opts.TerraformCliArgs, "-no-color"))
 	os.Setenv("TERRAGRUNT_LOGGING_LEVEL", fmt.Sprintf("%d", level))
+	os.Setenv("TERRAGRUNT_TFPATH", terraformPath)
 
 	parseEnvironmentVariables(opts, os.Environ())
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -84,14 +84,16 @@ USAGE:
    {{.Usage}}
 
 COMMANDS:
-   print-doc     Print the documentation of all extra_arguments, import_files, pre_hooks, post_hooks and extra_command
+   print-doc           Print the documentation of all extra_arguments, import_files, pre_hooks, post_hooks and extra_command
+   get-dependencies    Get a JSON representation of the dependencies between projects under the 'stack' (see -all operations)
+   get-versions        Get all versions of underlying tools (including extra_command)
 
    -all operations:
-   plan-all      Display the plans of a 'stack' by running 'terragrunt plan' in each subfolder (with a summary at the end)
-   apply-all     Apply a 'stack' by running 'terragrunt apply' in each subfolder
-   output-all    Display the outputs of a 'stack' by running 'terragrunt output' in each subfolder (no error if a subfolder doesn't have outputs)
-   destroy-all   Destroy a 'stack' by running 'terragrunt destroy' in each subfolder in reverse dependency order
-   *-all         In fact, the -all could be applied on any terraform or custom commands (that's cool)
+   plan-all            Display the plans of a 'stack' by running 'terragrunt plan' in each subfolder (with a summary at the end)
+   apply-all           Apply a 'stack' by running 'terragrunt apply' in each subfolder
+   output-all          Display the outputs of a 'stack' by running 'terragrunt output' in each subfolder (no error if a subfolder doesn't have outputs)
+   destroy-all         Destroy a 'stack' by running 'terragrunt destroy' in each subfolder in reverse dependency order
+   *-all               In fact, the -all could be applied on any terraform or custom commands (that's cool)
 
    terraform commands:
    *             Terragrunt forwards all other commands directly to Terraform
@@ -284,6 +286,11 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) 
 
 	terragruntOptions.IgnoreRemainingInterpolation = false
 	conf.SubstituteAllVariables(terragruntOptions, true)
+
+	if actualCommand.Command == "get-versions" {
+		PrintVersions(terragruntOptions, conf)
+		os.Exit(0)
+	}
 
 	if actualCommand.Command == "print-doc" {
 		PrintDoc(terragruntOptions, conf)

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/fatih/color"
 	"github.com/gruntwork-io/terragrunt/aws_helper"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/configstack"
@@ -162,10 +163,13 @@ func runApp(cliContext *cli.Context) (finalErr error) {
 
 	// If someone calls us with no args at all, show the help text and exit
 	if !cliContext.Args().Present() {
+		title := color.New(color.FgYellow, color.Underline).SprintFunc()
+		fmt.Println(title("\nTERRAGRUNT\n"))
 		cli.ShowAppHelp(cliContext)
 
 		fmt.Fprintln(cliContext.App.Writer)
 		util.SetWarningLoggingLevel()
+		fmt.Println(title("TERRAFORM\n"))
 		shell.RunTerraformCommand(terragruntOptions, "--help")
 		return nil
 	}
@@ -477,20 +481,20 @@ func getAll(terragruntOptions *options.TerragruntOptions) error {
 		return err
 	}
 
-	solver := make(map[string]float64, len(stack.Modules))
+	// solver := make(map[string]float64, len(stack.Modules))
 
-	depOrderMax := func(modules []*configstack.TerraformModule) float64 {
-		max := 0.0
-		for _, module := range modules {
-			if current, ok := solver[module.Path]; ok && current > max {
-				max = current
-			}
-		}
-		return 0
-	}
+	// depOrderMax := func(modules []*configstack.TerraformModule) float64 {
+	// 	max := 0.0
+	// 	for _, module := range modules {
+	// 		if current, ok := solver[module.Path]; ok && current > max {
+	// 			max = current
+	// 		}
+	// 	}
+	// 	return 0
+	// }
 
 	sortedModules := make([]string, 0, len(stack.Modules))
-	base := 100.0
+	// base := 100.0
 	currentDir, _ := os.Getwd()
 	for _, module := range stack.Modules {
 		module.Path, _ = filepath.Rel(currentDir, module.Path)

--- a/cli/print_doc.go
+++ b/cli/print_doc.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/fatih/color"
+
+	"github.com/gruntwork-io/terragrunt/config"
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
+)
+
+var title = color.New(color.FgHiWhite)
+var item = color.New(color.FgHiYellow).SprintFunc()
+
+// PrintDoc prints the contextual documentation relative to the current project
+func PrintDoc(terragruntOptions *options.TerragruntOptions, conf *config.TerragruntConfig) {
+	fmt.Println(conf.Description)
+	title.Println("Extra arguments: (in evaluation order):")
+	fmt.Println(util.Indent(extraArgs(conf.Terraform.ExtraArgs), 4))
+
+	title.Println("File importers (in execution order):")
+	fmt.Println(util.Indent(importers(conf.ImportFiles, terragruntOptions.WorkingDir), 4))
+
+	title.Println("Pre hooks (in execution order):")
+	fmt.Println(util.Indent(hooks(conf.PreHooks, false), 4))
+	fmt.Println(util.Indent(item("Initialize Terraform state\n"), 4))
+	fmt.Println(util.Indent(hooks(conf.PreHooks, true), 4))
+
+	title.Println("Post hooks (in execution order):")
+	fmt.Println(util.Indent(hooks(conf.PostHooks), 4))
+
+	title.Println("Extra commands available:")
+	fmt.Println(util.Indent(extraCommands(conf.ExtraCommands), 4))
+}
+
+func extraArgs(extraArgs []config.TerraformExtraArguments) (out string) {
+	for _, args := range extraArgs {
+		out += fmt.Sprintf("\n%s\n", item(args.Name))
+		if args.Description != "" {
+			out += fmt.Sprintf("\n%s\n", args.Description)
+		}
+		if args.Commands != nil {
+			out += fmt.Sprintf("\nApplies on the following command(s): %s\n", strings.Join(args.Commands, ", "))
+		}
+		if args.Arguments != nil {
+			out += fmt.Sprintf("\nAutomatically add the following parameter(s): %s\n", strings.Join(args.Arguments, ", "))
+		}
+	}
+	return
+}
+
+func importers(importers []config.ImportConfig, cwd string) (out string) {
+	for _, importer := range importers {
+		out += fmt.Sprintf("\n%s\n", item(importer.Name))
+		if importer.Description != "" {
+			out += fmt.Sprintf("\n%s\n", importer.Description)
+		}
+		if importer.Source != "" {
+			out += fmt.Sprintf("\nFrom %s:\n", importer.Source)
+		} else {
+			out += fmt.Sprint("\nFile(s):\n")
+		}
+
+		prefix := importer.Name + "_"
+		if importer.Prefix != nil {
+			prefix = *importer.Prefix
+		}
+
+		target, _ := filepath.Rel(cwd, importer.Target)
+		for _, file := range importer.Files {
+			target := filepath.Join(target, fmt.Sprintf("%s%s", prefix, filepath.Base(file)))
+			if strings.Contains(file, "/terragrunt-cache/") {
+				file = filepath.Base(file)
+			}
+			out += fmt.Sprintf("   %s → %s\n", file, target)
+		}
+
+		required := true
+		if importer.Required != nil {
+			required = *importer.Required
+		}
+
+		attributes := []string{fmt.Sprintf("Required = %v", required)}
+		if importer.ImportIntoModules {
+			attributes = append(attributes, "Import into modules")
+		}
+		if importer.FileMode != nil {
+			attributes = append(attributes, fmt.Sprintf("File mode = %#o", *importer.FileMode))
+		}
+		out += fmt.Sprintf("\n%s\n", strings.Join(attributes, ", "))
+	}
+	return
+}
+
+func hooks(hooks []config.Hook, afterInitState ...bool) (out string) {
+	sort.Sort(hooksByOrder(hooks))
+
+	for _, hook := range hooks {
+		if afterInitState != nil && hook.AfterInitState != afterInitState[0] {
+			continue
+		}
+		out += fmt.Sprintf("\n%s\n", item(hook.Name))
+		if hook.Description != "" {
+			out += fmt.Sprintf("\n%s\n", hook.Description)
+		}
+		out += fmt.Sprintf("\nCommand: %s %s\n", hook.Command, strings.Join(hook.Arguments, " "))
+		if hook.OnCommands != nil {
+			out += fmt.Sprintf("\nApplies on the following command(s): %s\n", strings.Join(hook.OnCommands, ", "))
+		}
+		if hook.OS != nil {
+			out += fmt.Sprintf("\nApplied only on the following OS: %s\n", strings.Join(hook.OS, ", "))
+		}
+		attributes := []string{
+			fmt.Sprintf("Order = %d", hook.Order),
+			fmt.Sprintf("Expand arguments = %v", hook.ExpandArgs),
+			fmt.Sprintf("Ignore error = %v", hook.IgnoreError),
+		}
+		out += fmt.Sprintf("\n%s\n", strings.Join(attributes, ", "))
+	}
+	return
+}
+
+type extraCommandsByName []config.ExtraCommand
+
+func (e extraCommandsByName) Len() int      { return len(e) }
+func (e extraCommandsByName) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+func (e extraCommandsByName) Less(i, j int) bool {
+	return e[i].Name < e[j].Name
+}
+
+func extraCommands(extraCommands []config.ExtraCommand) (out string) {
+	sort.Sort(extraCommandsByName(extraCommands))
+	for _, cmd := range extraCommands {
+		var aliases string
+		commands := append(cmd.Commands, cmd.Aliases...)
+		if commands != nil {
+			sort.Strings(commands)
+			aliases = fmt.Sprintf(" | %s", strings.Join(commands, " | "))
+		}
+		out += fmt.Sprintf("\n%s%s\n", item(cmd.Name), aliases)
+
+		if cmd.Description != "" {
+			out += fmt.Sprintf("\n%s\n", cmd.Description)
+		}
+
+		if cmd.OS != nil {
+			out += fmt.Sprintf("\nApplied only on the following OS: %s\n", strings.Join(cmd.OS, ", "))
+		}
+
+		if cmd.Arguments != nil {
+			out += fmt.Sprintf("\nAutomatically added argument(s): %s\n", strings.Join(cmd.Arguments, ", "))
+		}
+	}
+	return
+}

--- a/cli/run_config.go
+++ b/cli/run_config.go
@@ -278,10 +278,13 @@ func getActualCommand(terragruntOptions *options.TerragruntOptions, config *conf
 			if extraCommand.ActAs != "" {
 				// The command must act as another command for extra argument validation
 				terragruntOptions.TerraformCliArgs[0] = extraCommand.ActAs
-			} else if extraCommand.UseState == nil || *extraCommand.UseState {
-				// We simulate that the extra command acts as the plan command to init the state file
-				// and get the modules
-				behaveAs = "plan"
+			} else {
+				extraCommand.ActAs = cmd
+				if extraCommand.UseState == nil || *extraCommand.UseState {
+					// We simulate that the extra command acts as the plan command to init the state file
+					// and get the modules
+					behaveAs = "plan"
+				}
 			}
 
 			return actualCommand{cmd, behaveAs, &extraCommand}

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -2,11 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/hashicorp/go-version"
-	"regexp"
 )
 
 // The terraform --version output is of the format: Terraform v0.9.5-dev (cad024a5fe131a546936674ef85445215bbc4226+CHANGES)
@@ -21,6 +22,7 @@ func CheckTerraformVersion(constraint string, terragruntOptions *options.Terragr
 		return err
 	}
 
+	terraformVersion = currentVersion.String()
 	return checkTerraformVersionMeetsConstraint(currentVersion, constraint)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -381,7 +381,6 @@ func ParseConfigFile(terragruntOptions *options.TerragruntOptions, include Inclu
 		}
 		include.Path, configString, err = util.ReadFileAsStringFromSource(include.Source, include.Path, terragruntOptions.Logger)
 		source = filepath.Join(include.Source, include.Path)
-
 	}
 	if err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -220,6 +220,7 @@ type ExtraCommand struct {
 	ExpandArgs  *bool    `hcl:"expand_args,omitempty"`
 	UseState    *bool    `hcl:"use_state,omitempty"`
 	ActAs       string   `hcl:"act_as,omitempty"`
+	VersionArg  string   `hcl:"version,omitempty"`
 }
 
 func (command *ExtraCommand) String() string {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,8 +2,11 @@ package errors
 
 import (
 	"fmt"
+
 	goerrors "github.com/go-errors/errors"
 )
+
+const CHANGE_EXIT_CODE = 2
 
 // Wrap the given error in an Error type that contains the stack trace. If the given error already has a stack trace,
 // it is used directly. If the given error is nil, return nil.
@@ -76,4 +79,14 @@ func Recover(onPanic func(cause error)) {
 // Interface to determine if we can retrieve an exit status from an error
 type IErrorCode interface {
 	ExitStatus() (int, error)
+}
+
+type PlanWithChanges struct{}
+
+func (err PlanWithChanges) Error() string {
+	return "There are changes in the plan"
+}
+
+func (err PlanWithChanges) ExitStatus() (int, error) {
+	return CHANGE_EXIT_CODE, nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -91,7 +91,7 @@ imports:
   - parser
   - scanner
 - name: github.com/hashicorp/terraform
-  version: 8ba8fc79c106dee098c625f4c40cd53d73660a92
+  version: a1d06eb97378d097d4175c3284ea026937618477
   subpackages:
   - config
   - config/module

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,14 @@
 hash: efc2903a6372744db3015558a99edec989815bb1893f899eade91af6b0d5d70a
-updated: 2017-08-03T12:38:44.756027183-04:00
+updated: 2017-10-24T11:23:38.596142532-04:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: 2bd8b58cf4275aeb086ade613de226773e29e853
   subpackages:
   - cidr
+- name: github.com/armon/go-radix
+  version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
 - name: github.com/aws/aws-sdk-go
-  version: b33b08175d12b795daa7726c5577b39d06a2551c
+  version: 209e63d002840d9ed94159e6639216a53b7cc28b
   subpackages:
   - aws
   - aws/awserr
@@ -43,22 +45,26 @@ imports:
   version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
   subpackages:
   - netrc
+- name: github.com/bgentry/speakeasy
+  version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
 - name: github.com/blang/semver
   version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
+- name: github.com/fatih/color
+  version: 5df930a27be2502f99b292b7cc09ebad4d0891f4
 - name: github.com/go-errors/errors
   version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/go-ini/ini
-  version: 3d73f4b845efdf9989fffd4b4e562727744a34ba
+  version: f384f410798cbe7cdce40eec40b79ed32bb4f1ad
 - name: github.com/hashicorp/errwrap
   version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
 - name: github.com/hashicorp/go-cleanhttp
   version: 3573b8b52aa7b37b9358d966a898feb387f62437
 - name: github.com/hashicorp/go-getter
-  version: 6aae8e4e2dee8131187c6a54b52664796e5a02b0
+  version: 2f449c791e6af9e532bc1aca36d1d3865b8537f9
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-multierror
@@ -66,9 +72,9 @@ imports:
 - name: github.com/hashicorp/go-uuid
   version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
 - name: github.com/hashicorp/go-version
-  version: 03c5bf6be031b6dd45afec16b1cf94fc8938bc77
+  version: fc61389e27c71d120f87031ca8c88a3428f372dd
 - name: github.com/hashicorp/hcl
-  version: 392dba7d905ed5d04a5794ba89f558b27e2ba1ca
+  version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -85,7 +91,7 @@ imports:
   - parser
   - scanner
 - name: github.com/hashicorp/terraform
-  version: 2041053ee9444fa8175a298093b55a89586a1823
+  version: 8ba8fc79c106dee098c625f4c40cd53d73660a92
   subpackages:
   - config
   - config/module
@@ -94,20 +100,26 @@ imports:
   - plugin/discovery
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/mattn/go-colorable
+  version: ad5389df28cdac544c99bd7b9161a0b5b6ca9d1b
+- name: github.com/mattn/go-isatty
+  version: a5cdd64afdee435007ee3e9f6ed4684af949d568
 - name: github.com/mattn/go-zglob
-  version: 95345c4e1c0ebc9d16a3284177f09360f4d20fab
+  version: 4ecb59231939b2e499b1f2fd8f075565977d2452
   subpackages:
   - fastwalk
+- name: github.com/mitchellh/cli
+  version: 65fcae5817c8600da98ada9d7edf26dd1a84837b
 - name: github.com/mitchellh/copystructure
   version: d23ffcb85de31694d6ccaa23ccb4a03e55c1303f
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/go-testing-interface
-  version: 9a441910b16872f7b8283682619b3761a9aa2222
+  version: a61a99592b77c9ba629d254a693acffaeb4b7e28
 - name: github.com/mitchellh/hashstructure
   version: 2bca23e0e452137f789efbc8610126fd8b94f73b
 - name: github.com/mitchellh/mapstructure
-  version: d0303fe809921458f417bcf828397a65db30a7e4
+  version: 06020f85339e21b2478f756a78e295255ffa4d6a
 - name: github.com/mitchellh/reflectwalk
   version: 63d60e9d0dbc60cf9164e6510889b0db6683d98c
 - name: github.com/op/go-logging
@@ -116,6 +128,12 @@ imports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/posener/complete
+  version: 88e59760adaddb8276c9b15511302890690e2dae
+  subpackages:
+  - cmd
+  - cmd/install
+  - match
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
@@ -127,9 +145,9 @@ imports:
   - internal/xlog
   - lzma
 - name: github.com/urfave/cli
-  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+  version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: golang.org/x/crypto
-  version: 358f15eacb587b056fc93273b930314a5cda12fe
+  version: 2509b142fb2b797aa7587dad548f113b2c0f20ce
   subpackages:
   - bcrypt
   - blowfish
@@ -141,10 +159,14 @@ imports:
   - openpgp/packet
   - openpgp/s2k
 - name: golang.org/x/net
-  version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
+  version: 4b14673ba32bee7f5ac0f990a48f033919fd418b
   subpackages:
   - html
   - html/atom
+- name: golang.org/x/sys
+  version: a1a1f1746d156bbc9954f29134b20ed4ce2752f1
+  subpackages:
+  - unix
 - name: gopkg.in/yaml.v2
-  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -91,7 +91,7 @@ imports:
   - parser
   - scanner
 - name: github.com/hashicorp/terraform
-  version: a1d06eb97378d097d4175c3284ea026937618477
+  version: 8ba8fc79c106dee098c625f4c40cd53d73660a92
   subpackages:
   - config
   - config/module

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/gruntwork-io/terragrunt/cli"
@@ -29,11 +30,17 @@ func checkForErrorsAndExit(err error) {
 		os.Exit(0)
 	} else {
 		logger := util.CreateLogger("")
-		if os.Getenv("TERRAGRUNT_DEBUG") != "" {
-			logger.Error(errors.PrintErrorWithStackTrace(err))
-		} else {
-			logger.Error(err)
+
+		if _, ok := errors.Unwrap(err).(errors.PlanWithChanges); !ok {
+			// Plan status are not considred as an error
+			fmt.Printf("Error type %T\n", err)
+			if os.Getenv("TERRAGRUNT_DEBUG") != "" {
+				logger.Error(errors.PrintErrorWithStackTrace(err))
+			} else {
+				logger.Error(err)
+			}
 		}
+
 		// exit with the underlying error code
 		exitCode, exitCodeErr := shell.GetExitCode(err)
 		if exitCodeErr != nil {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/gruntwork-io/terragrunt/cli"
@@ -33,7 +32,6 @@ func checkForErrorsAndExit(err error) {
 
 		if _, ok := errors.Unwrap(err).(errors.PlanWithChanges); !ok {
 			// Plan status are not considred as an error
-			fmt.Printf("Error type %T\n", err)
 			if os.Getenv("TERRAGRUNT_DEBUG") != "" {
 				logger.Error(errors.PrintErrorWithStackTrace(err))
 			} else {

--- a/util/file.go
+++ b/util/file.go
@@ -275,6 +275,7 @@ func ExpandArguments(args []string, folder string) (result []string) {
 	prefix := folder + string(filepath.Separator)
 
 	for _, arg := range args {
+		arg = os.ExpandEnv(arg)
 		if strings.ContainsAny(arg, "*?[]") {
 			if !filepath.IsAbs(arg) {
 				arg = prefix + arg

--- a/util/strings.go
+++ b/util/strings.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"strings"
+)
+
+// UnIndent returns the unindented version of the supplied string
+func UnIndent(s string) string {
+	if !strings.HasPrefix(s, " ") || !strings.Contains(s, "\n") {
+		// There is no indentation on the first line
+		return s
+	}
+	split := strings.Split(s, "\n")
+
+	// Count the number of spaces on the first line
+	i := 0
+	for ; i < len(split[0]); i++ {
+		if split[0][i] != ' ' {
+			break
+		}
+	}
+
+	// Remove the indentation (preserving the indentation relative to the first line)
+	prefix := strings.Repeat(" ", i)
+	for i := range split {
+		split[i] = strings.TrimPrefix(split[i], prefix)
+	}
+	return strings.Join(split, "\n")
+}
+
+// Indent returns the indented version of the supplied string
+func Indent(s string, indent int) string {
+	split := strings.Split(s, "\n")
+	space := strings.Repeat(" ", indent)
+
+	for i := range split {
+		split[i] = space + split[i]
+	}
+	return strings.Join(split, "\n")
+}


### PR DESCRIPTION
Add a field Description to most of the customizable elements
Export TERRAGRUNT_TFPATH, TERRAGRUNT_VERSION, TERRAFORM_VERSION, TERRAGRUNT_COMMAND and TERRAGRUNT_EXTRA_COMMAND to make it available to sub processes
Improve the behaviour of extra command
Allow the possibility to expand environment variables automatically in arguments
Add utility functions to indent and unindent strings