### PR TITLE
Approval config now in the terraform.tfvars file

### DIFF
--- a/cli/args.go
+++ b/cli/args.go
@@ -70,7 +70,6 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 	loggingLevel := parse(OPT_LOGGING_LEVEL, os.Getenv("TERRAGRUNT_LOGGING_LEVEL"))
 	awsProfile := parse(OPT_AWS_PROFILE)
 	approvalHandler := parse(OPT_APPROVAL_HANDLER)
-	approvalConfigFile := parse(OPT_APPROVAL_CONFIG)
 	sourceUpdate := parseBooleanArg(args, OPT_TERRAGRUNT_SOURCE_UPDATE, false)
 	ignoreDependencyErrors := parseBooleanArg(args, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS, false)
 
@@ -92,7 +91,6 @@ func parseTerragruntOptionsFromArgs(args []string) (*options.TerragruntOptions, 
 	opts.Variables = options.VariableList{}
 	opts.AwsProfile = awsProfile
 	opts.ApprovalHandler = approvalHandler
-	opts.ApprovalConfigFile = approvalConfigFile
 
 	level, err := util.InitLogging(loggingLevel, logging.NOTICE, !util.ListContainsElement(opts.TerraformCliArgs, "-no-color"))
 	os.Setenv("TERRAGRUNT_LOGGING_LEVEL", fmt.Sprintf("%d", level))

--- a/config/config.go
+++ b/config/config.go
@@ -26,16 +26,17 @@ const (
 
 // TerragruntConfig represents a parsed and expanded configuration
 type TerragruntConfig struct {
-	Description   string              `hcl:"description"`
-	Terraform     *TerraformConfig    `hcl:"terraform"`
-	RemoteState   *remote.RemoteState `hcl:"remote_state"`
-	Dependencies  *ModuleDependencies `hcl:"dependencies"`
-	Uniqueness    *string             `hcl:"uniqueness_criteria"`
-	AssumeRole    *string             `hcl:"assume_role"`
-	PreHooks      HookList            `hcl:"pre_hook"`
-	PostHooks     HookList            `hcl:"post_hook"`
-	ExtraCommands ExtraCommandList    `hcl:"extra_command"`
-	ImportFiles   ImportFilesList     `hcl:"import_files"`
+	Description    string              `hcl:"description"`
+	Terraform      *TerraformConfig    `hcl:"terraform"`
+	RemoteState    *remote.RemoteState `hcl:"remote_state"`
+	Dependencies   *ModuleDependencies `hcl:"dependencies"`
+	Uniqueness     *string             `hcl:"uniqueness_criteria"`
+	AssumeRole     *string             `hcl:"assume_role"`
+	PreHooks       HookList            `hcl:"pre_hook"`
+	PostHooks      HookList            `hcl:"post_hook"`
+	ExtraCommands  ExtraCommandList    `hcl:"extra_command"`
+	ImportFiles    ImportFilesList     `hcl:"import_files"`
+	ApprovalConfig ApprovalConfigList  `hcl:"approval_config"`
 
 	options *options.TerragruntOptions
 }
@@ -122,6 +123,29 @@ type ModuleDependencies struct {
 
 func (deps *ModuleDependencies) String() string {
 	return fmt.Sprintf("ModuleDependencies{Paths = %v}", deps.Paths)
+}
+
+// ApprovalConfig represents an `expect` format configuration that instructs terragrunt to wait for input on an ExpectStatement
+// and to exit the command on a CompletedStatement
+type ApprovalConfig struct {
+	Command             string   `hcl:"command"`
+	ExpectStatements    []string `hcl:"expect_statements"`
+	CompletedStatements []string `hcl:"completed_statements"`
+}
+
+func (conf ApprovalConfig) String() string {
+	return util.PrettyPrintStruct(conf)
+}
+
+type ApprovalConfigList []*ApprovalConfig
+
+func (list ApprovalConfigList) ShouldBeApproved(command string) (bool, *ApprovalConfig) {
+	for _, approvalConfig := range list {
+		if approvalConfig.Command == command {
+			return true, approvalConfig
+		}
+	}
+	return false, nil
 }
 
 // TerraformConfig specifies where to find the Terraform configuration files

--- a/config/extension_hook.go
+++ b/config/extension_hook.go
@@ -61,12 +61,10 @@ func (hook *Hook) run(args ...interface{}) (result []interface{}, err error) {
 		return
 	}
 
-	cmd := shell.RunShellCommand
-	if hook.ExpandArgs {
-		cmd = shell.RunShellCommandExpandArgs
-	}
-	if err = cmd(hook.options(), hook.Command, hook.Arguments...); err != nil && !hook.IgnoreError {
-		err = fmt.Errorf("%v while running command %s: %s %s", err, hook.Name, hook.Command, strings.Join(hook.Arguments, " "))
+	if shouldBeApproved, approvalConfig := hook._config.ApprovalConfig.ShouldBeApproved(hook.Command); shouldBeApproved {
+		err = shell.RunShellCommandWithApproval(hook.options(), approvalConfig.ExpectStatements, approvalConfig.CompletedStatements, hook.ExpandArgs, hook.Command, hook.Arguments...)
+	} else {
+		err = shell.RunShellCommand(hook.options(), hook.ExpandArgs, hook.Command, hook.Arguments...)
 	}
 	return
 }

--- a/options/options.go
+++ b/options/options.go
@@ -31,10 +31,6 @@ type TerragruntOptions struct {
 	// The approval handler that will be used in a non interactive context
 	ApprovalHandler string
 
-	// The approval config file, this file must be YAML formatted and contains the input text to expect and the completion text.
-	// The default value is defined in the approval handler file
-	ApprovalConfigFile string
-
 	// CLI args that are intended for Terraform (i.e. all the CLI args except the --terragrunt ones)
 	TerraformCliArgs []string
 
@@ -152,7 +148,6 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		Writer:                       terragruntOptions.Writer,
 		ErrWriter:                    terragruntOptions.ErrWriter,
 		ApprovalHandler:              terragruntOptions.ApprovalHandler,
-		ApprovalConfigFile:           terragruntOptions.ApprovalConfigFile,
 		RunTerragrunt:                terragruntOptions.RunTerragrunt,
 		Uniqueness:                   terragruntOptions.Uniqueness,
 		IgnoreRemainingInterpolation: terragruntOptions.IgnoreRemainingInterpolation,

--- a/shell/approval_handler.go
+++ b/shell/approval_handler.go
@@ -5,7 +5,6 @@ import (
 	goErrors "errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -13,40 +12,19 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terragrunt/options"
-	"github.com/gruntwork-io/terragrunt/util"
-	"gopkg.in/yaml.v2"
 )
-
-// CommandShouldBeApproved returns true if the command to run should go through the approval process (expect style)
-// It will return false if -auto-approve is set and if the command is not in the commands list of the config.
-func CommandShouldBeApproved(command string, terragruntOptions *options.TerragruntOptions) bool {
-	if util.ListContainsElement(terragruntOptions.TerraformCliArgs, "-auto-approve") {
-		return false
-	}
-	config, err := getApprovalConfig(terragruntOptions)
-	if err != nil {
-		panic(err)
-	}
-
-	for _, commandToApprove := range config.Commands {
-		if strings.Contains(command, commandToApprove) {
-			return true
-		}
-	}
-	return false
-}
 
 var sharedMutex = sync.Mutex{}
 
 // RunCommandToApprove runs a command with approval (expect style)
-func RunCommandToApprove(cmd *exec.Cmd, terragruntOptions *options.TerragruntOptions) error {
+func RunCommandToApprove(cmd *exec.Cmd, expectedStatements []string, completedStatements []string, terragruntOptions *options.TerragruntOptions) error {
 	sharedMutex.Lock()
 	defer sharedMutex.Unlock()
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return err
 	}
-	stdOutInterceptor := newOutputInterceptor(cmd.Stdout, terragruntOptions)
+	stdOutInterceptor := newOutputInterceptor(cmd.Stdout, expectedStatements, completedStatements)
 	cmd.Stdout = stdOutInterceptor
 	err = cmd.Start()
 	if err != nil {
@@ -122,22 +100,17 @@ func approveWithCustomHandler(terragruntOptions *options.TerragruntOptions, prom
 // OutputInterceptor intercepts all writes to a io.Writer and writes them to a buffer while still letting them pass through.
 // Offers some functions to help the approval process.
 type OutputInterceptor struct {
-	subWriter          io.Writer
-	buffer             []byte
-	expectStatements   []string
-	completeStatements []string
+	subWriter           io.Writer
+	buffer              []byte
+	expectedStatements  []string
+	completedStatements []string
 }
 
-func newOutputInterceptor(subWriter io.Writer, terragruntOptions *options.TerragruntOptions) *OutputInterceptor {
-	config, err := getApprovalConfig(terragruntOptions)
-	if err != nil {
-		panic(err)
-	}
-
+func newOutputInterceptor(subWriter io.Writer, expectedStatements []string, completedStatements []string) *OutputInterceptor {
 	return &OutputInterceptor{
-		subWriter:          subWriter,
-		expectStatements:   config.Expect,
-		completeStatements: config.Complete,
+		subWriter:           subWriter,
+		expectedStatements:  expectedStatements,
+		completedStatements: completedStatements,
 	}
 }
 
@@ -153,12 +126,12 @@ func (interceptor *OutputInterceptor) GetBuffer() string {
 
 // WaitingForValue returns true if the command is waiting for an input value based on its output.
 func (interceptor *OutputInterceptor) WaitingForValue() bool {
-	return interceptor.IsComplete() || interceptor.bufferContainsString(interceptor.expectStatements)
+	return interceptor.IsComplete() || interceptor.bufferContainsString(interceptor.expectedStatements)
 }
 
 // IsComplete returns true if the command is complete and should exit.
 func (interceptor *OutputInterceptor) IsComplete() bool {
-	return interceptor.bufferContainsString(interceptor.completeStatements)
+	return interceptor.bufferContainsString(interceptor.completedStatements)
 }
 
 func (interceptor *OutputInterceptor) bufferContainsString(listOfStrings []string) bool {
@@ -169,45 +142,3 @@ func (interceptor *OutputInterceptor) bufferContainsString(listOfStrings []strin
 	}
 	return false
 }
-
-// ApprovalConfig represents the config file that can be provided to modify the approval process. See the default config below for an example.
-type ApprovalConfig struct {
-	Commands []string
-	Expect   []string
-	Complete []string
-}
-
-func getApprovalConfig(terragruntOptions *options.TerragruntOptions) (config *ApprovalConfig, err error) {
-	if approvalConfig != nil {
-		return approvalConfig, nil
-	}
-
-	if terragruntOptions.ApprovalConfigFile != "" {
-		var (
-			path    string
-			content []byte
-		)
-
-		if path, err = LookPath(terragruntOptions.ApprovalConfigFile, terragruntOptions.Env["PATH"]); err != nil {
-			return
-		}
-
-		if content, err = ioutil.ReadFile(path); err != nil {
-			return
-		}
-		if err = yaml.Unmarshal(content, config); err != nil {
-			config = approvalConfig
-			return
-		}
-	} else {
-		config = &ApprovalConfig{
-			[]string{"apply"},
-			[]string{"Apply complete!", "Apply cancelled.", "Error:"},
-			[]string{"Do you want to perform these actions"},
-		}
-	}
-	approvalConfig = config
-	return
-}
-
-var approvalConfig *ApprovalConfig


### PR DESCRIPTION
Approval decision is now made before entering the "shell" module. The approval process will not be used by default, it needs a config.