### PR TITLE
Several changes following code refactoring

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -33,10 +33,11 @@ const OPT_TERRAGRUNT_SOURCE = "terragrunt-source"
 const OPT_TERRAGRUNT_SOURCE_UPDATE = "terragrunt-source-update"
 const OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS = "terragrunt-ignore-dependency-errors"
 const OPT_LOGGING_LEVEL = "terragrunt-logging-level"
+const OPT_FLUSH_DELAY = "terragrunt-flush-delay"
 const OPT_AWS_PROFILE = "profile"
 
 var ALL_TERRAGRUNT_BOOLEAN_OPTS = []string{OPT_NON_INTERACTIVE, OPT_TERRAGRUNT_SOURCE_UPDATE, OPT_TERRAGRUNT_IGNORE_DEPENDENCY_ERRORS}
-var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_TFPATH, OPT_WORKING_DIR, OPT_TERRAGRUNT_SOURCE, OPT_LOGGING_LEVEL, OPT_AWS_PROFILE, OPT_APPROVAL_HANDLER}
+var ALL_TERRAGRUNT_STRING_OPTS = []string{OPT_TERRAGRUNT_CONFIG, OPT_TERRAGRUNT_TFPATH, OPT_WORKING_DIR, OPT_TERRAGRUNT_SOURCE, OPT_LOGGING_LEVEL, OPT_AWS_PROFILE, OPT_APPROVAL_HANDLER, OPT_FLUSH_DELAY}
 
 const MULTI_MODULE_SUFFIX = "-all"
 const CMD_INIT = "init"
@@ -85,11 +86,11 @@ USAGE:
    {{.Usage}}
 
 COMMANDS:
+   <command> --help | -h               Print the command detailed help 
+
    get-doc [options...] [filters...] Print the documentation of all extra_arguments, import_files, pre_hooks, post_hooks and extra_command.
    get-versions                      Get all versions of underlying tools (including extra_command).
    get-stack [options]               Get the list of stack to execute sorted by dependency order.
-
-   command --help | -h               Print the command detailed help 
 
    -all operations:
    plan-all                          Display the plans of a 'stack' by running 'terragrunt plan' in each subfolder (with a summary at the end).
@@ -111,6 +112,7 @@ GLOBAL OPTIONS:
    terragrunt-ignore-dependency-errors  *-all commands continue processing components even if a dependency fails.
    terragrunt-logging-level             CRITICAL (0), ERROR (1), WARNING (2), NOTICE (3), INFO (4), DEBUG (5).
    terragrunt-approval                  Program to use for approval. {val} will be replaced by the current terragrunt output. Ex: approval.py --value {val}
+   terragrunt-flush-delay               Maximum delay on -all commands before printing out traces (NOTICE) indicating that the process is still alive (default 60 seconds)
    profile                              Specify an AWS profile to use.
 
 VERSION:

--- a/cli/version_check.go
+++ b/cli/version_check.go
@@ -42,7 +42,7 @@ func checkTerraformVersionMeetsConstraint(currentVersion *version.Version, const
 
 // Get the currently installed version of Terraform
 func getTerraformVersion(terragruntOptions *options.TerragruntOptions) (*version.Version, error) {
-	output, err := shell.RunTerraformCommandAndCaptureOutput(terragruntOptions, "--version")
+	output, err := shell.NewTFCmd(terragruntOptions).Args("--version").Output()
 	if err != nil {
 		return nil, err
 	}

--- a/config/extension_base_list.go
+++ b/config/extension_base_list.go
@@ -153,7 +153,7 @@ func (list GenericItemList) Run(args ...interface{}) (result []interface{}, err 
 	for _, item := range list {
 		iItem := IGenericItem(&item)
 		var temp interface{}
-		iItem.logger().Infof("Running %s(%s): %s", iItem.itemType(), iItem.id(), iItem.name())
+		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
 		if temp, err = iItem.run(args...); err != nil {
 			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)

--- a/config/extension_hook.go
+++ b/config/extension_hook.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/coveo/gotemplate/utils"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 )
@@ -73,6 +74,10 @@ func (hook *Hook) run(args ...interface{}) (result []interface{}, err error) {
 
 	if hook.ExpandArgs {
 		cmd = cmd.ExpandArgs()
+	}
+
+	if !utils.IsCommand(hook.Command) {
+		cmd.DisplayCommand = fmt.Sprintf("%s %s", hook.name(), strings.Join(hook.Arguments, " "))
 	}
 
 	if shouldBeApproved, approvalConfig := hook.config().ApprovalConfig.ShouldBeApproved(hook.Command); shouldBeApproved {

--- a/config/generated_approval_config.go
+++ b/config/generated_approval_config.go
@@ -152,7 +152,7 @@ func (list ApprovalConfigList) Run(args ...interface{}) (result []interface{}, e
 	for _, item := range list {
 		iItem := IApprovalConfig(&item)
 		var temp interface{}
-		iItem.logger().Infof("Running %s(%s): %s", iItem.itemType(), iItem.id(), iItem.name())
+		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
 		if temp, err = iItem.run(args...); err != nil {
 			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)

--- a/config/generated_extra_args.go
+++ b/config/generated_extra_args.go
@@ -152,7 +152,7 @@ func (list TerraformExtraArgumentsList) Run(args ...interface{}) (result []inter
 	for _, item := range list {
 		iItem := ITerraformExtraArguments(&item)
 		var temp interface{}
-		iItem.logger().Infof("Running %s(%s): %s", iItem.itemType(), iItem.id(), iItem.name())
+		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
 		if temp, err = iItem.run(args...); err != nil {
 			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)

--- a/config/generated_extra_command.go
+++ b/config/generated_extra_command.go
@@ -152,7 +152,7 @@ func (list ExtraCommandList) Run(args ...interface{}) (result []interface{}, err
 	for _, item := range list {
 		iItem := IExtraCommand(&item)
 		var temp interface{}
-		iItem.logger().Infof("Running %s(%s): %s", iItem.itemType(), iItem.id(), iItem.name())
+		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
 		if temp, err = iItem.run(args...); err != nil {
 			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)

--- a/config/generated_hooks.go
+++ b/config/generated_hooks.go
@@ -152,7 +152,7 @@ func (list HookList) Run(args ...interface{}) (result []interface{}, err error) 
 	for _, item := range list {
 		iItem := IHook(&item)
 		var temp interface{}
-		iItem.logger().Infof("Running %s(%s): %s", iItem.itemType(), iItem.id(), iItem.name())
+		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
 		if temp, err = iItem.run(args...); err != nil {
 			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)

--- a/config/generated_import_files.go
+++ b/config/generated_import_files.go
@@ -152,7 +152,7 @@ func (list ImportFilesList) Run(args ...interface{}) (result []interface{}, err 
 	for _, item := range list {
 		iItem := IImportFiles(&item)
 		var temp interface{}
-		iItem.logger().Infof("Running %s(%s): %s", iItem.itemType(), iItem.id(), iItem.name())
+		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
 		if temp, err = iItem.run(args...); err != nil {
 			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)

--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -1,0 +1,52 @@
+package configstack
+
+import (
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/gruntwork-io/terragrunt/util"
+)
+
+const (
+	maxThreadSimultaneousLaunch = 10
+	waitTimeBetweenThread       = 2
+)
+
+func initSlowDown() {
+	burstyLimiter = make(chan int, maxThreadSimultaneousLaunch)
+	for i := 0; i < maxThreadSimultaneousLaunch; i++ {
+		burstyLimiter <- i
+	}
+
+	go func() {
+		// Help avoiding all treads trying to start at the same moment
+		for _ = range time.Tick(waitTimeBetweenThread * time.Second) {
+			burstyLimiter <- -1
+		}
+	}()
+}
+
+func slowDown() { <-burstyLimiter }
+
+var burstyLimiter chan int
+
+// OutputPeriodicLogs displays current module output for long running request
+func (module *runningModule) OutputPeriodicLogs(completed *bool) {
+	if module.Module.TerragruntOptions.RefreshOutputDelay == 0 {
+		return
+	}
+	writer := module.Module.TerragruntOptions.Writer.(util.LogCatcher).Logger.Noticef
+	for {
+		time.Sleep(module.Module.TerragruntOptions.RefreshOutputDelay)
+		if *completed {
+			break
+		}
+		partialOutput := module.OutStream.String()
+		if len(partialOutput) > module.bufferIndex {
+			end := len(partialOutput)
+			partialOutput = partialOutput[module.bufferIndex:end]
+			writer("%s\n%s", color.CyanString("Still waiting for task to complete, partial output:"), partialOutput)
+			module.bufferIndex = end
+		}
+	}
+}

--- a/options/options.go
+++ b/options/options.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/coveo/gotemplate/hcl"
 	"github.com/gruntwork-io/terragrunt/errors"
@@ -84,6 +85,9 @@ type TerragruntOptions struct {
 	// resolving process. This allows further resolution of variables that are not initially defined.
 	IgnoreRemainingInterpolation bool
 
+	// Indicates the maximum wait time before flushing the output of a background job
+	RefreshOutputDelay time.Duration
+
 	// The list of files (should be only one) where to save files if save_variables() has been invoked by the user
 	deferredSaveList map[string]bool
 }
@@ -151,6 +155,7 @@ func (terragruntOptions *TerragruntOptions) Clone(terragruntConfigPath string) *
 		RunTerragrunt:                terragruntOptions.RunTerragrunt,
 		Uniqueness:                   terragruntOptions.Uniqueness,
 		IgnoreRemainingInterpolation: terragruntOptions.IgnoreRemainingInterpolation,
+		RefreshOutputDelay:           terragruntOptions.RefreshOutputDelay,
 		deferredSaveList:             terragruntOptions.deferredSaveList,
 	}
 

--- a/shell/run_shell_cmd_test.go
+++ b/shell/run_shell_cmd_test.go
@@ -11,9 +11,9 @@ func TestRunShellCommand(t *testing.T) {
 	t.Parallel()
 
 	terragruntOptions := options.NewTerragruntOptionsForTest("")
-	cmd := RunShellCommand(terragruntOptions, "terraform", "--version")
+	cmd := NewTFCmd(terragruntOptions).Args("--version").Run()
 	assert.Nil(t, cmd)
 
-	cmd = RunShellCommand(terragruntOptions, "terraform", "not-a-real-command")
+	cmd = NewTFCmd(terragruntOptions).Args("not-a-real-command").Run()
 	assert.Error(t, cmd)
 }

--- a/util/file.go
+++ b/util/file.go
@@ -332,12 +332,13 @@ func CleanPath(path string) string {
 }
 
 // ExpandArguments expands the list of arguments like x shell do
-func ExpandArguments(args []string, folder string) (result []string) {
+func ExpandArguments(args []interface{}, folder string) (result []interface{}) {
 	prefix := folder + string(filepath.Separator)
 
-	for _, arg := range args {
+	for _, argI := range args {
 		// We consider \$ as an escape char for $ and we do not want ExpandEnv to replace it right now
 		const stringEscape = "%StrEsc%"
+		arg := fmt.Sprint(argI)
 		arg = strings.Replace(arg, `\$`, stringEscape, -1)
 		arg = strings.Replace(os.ExpandEnv(arg), stringEscape, "$", -1)
 		if strings.ContainsAny(arg, "*?[]") && !strings.ContainsAny(arg, "$|`") {
@@ -349,10 +350,10 @@ func ExpandArguments(args []string, folder string) (result []string) {
 				for i := range expanded {
 					// We remove the prefix from the result as if it was executed directly in the folder directory
 					expanded[i] = strings.TrimPrefix(expanded[i], prefix)
+					result = append(result, expanded[i])
 				}
-				result = append(result, expanded...)
-				continue
 			}
+			continue
 		}
 		result = append(result, arg)
 	}

--- a/util/logger.go
+++ b/util/logger.go
@@ -28,9 +28,9 @@ func SetWarningLoggingLevel() {
 func InitLogging(levelName string, defaultLevel logging.Level, color bool) (int, error) {
 	var format string
 	if color {
-		format = `[terragrunt%{module}] %{time:2006/01/02 15:04:05} %{color}%{level:-8s} %{message}%{color:reset}`
+		format = `[terragrunt%{module}] %{time:2006/01/02 15:04:05.000} %{color}%{level:-8s} %{message}%{color:reset}`
 	} else {
-		format = `[terragrunt%{module}] %{time:2006/01/02 15:04:05} %{level:-8s} %{message}`
+		format = `[terragrunt%{module}] %{time:2006/01/02 15:04:05.000} %{level:-8s} %{message}`
 	}
 
 	logging.SetBackend(logging.NewBackendFormatter(logging.NewLogBackend(os.Stderr, "", 0), logging.MustStringFormatter(format)))


### PR DESCRIPTION
- Refactor the exec package to use a command builder instead of having a bunch of functions with several parameters.
- Fix problem in the import-files option when referring to local file
- Fix the mechanism to print the current version of tools included in the configuration
- Fix problem when a hook or an extra command instantiate a shell and output is redirected