### PR TITLE
Import files with patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ terraform {
     key        = "frontend-app/terraform.tfstate"
     region     = "us-east-1"
     encrypt    = true
-    lock_table = "my-lock-table"
+    dynamodb_table = "my-lock-table"
   }
 }
 ```
@@ -473,7 +473,7 @@ terragrunt = {
       key        = "${path_relative_to_include()}/terraform.tfstate"
       region     = "us-east-1"
       encrypt    = true
-      lock_table = "my-lock-table"
+      dynamodb_table = "my-lock-table"
     }
   }
 }
@@ -544,8 +544,8 @@ they don't already exist:
   automatically, with [versioning enabled](http://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html).
 
 * **DynamoDB table**: If you are using the [S3 backend](https://www.terraform.io/docs/backends/types/s3.html) for
-  remote state storage and you specify a `lock_table` (a [DynamoDB table used for
-  locking](https://www.terraform.io/docs/backends/types/s3.html#lock_table)) in `remote_state.config`, if that table
+  remote state storage and you specify a `dynamodb_table` (a [DynamoDB table used for
+  locking](https://www.terraform.io/docs/backends/types/s3.html#dynamodb_table)) in `remote_state.config`, if that table
   doesn't already exist, Terragrunt will create it automatically, including a primary key called `LockID`.
 
 **Note**: If you specify a `profile` key in `remote_state.config`, Terragrunt will automatically use this AWS profile
@@ -1058,7 +1058,7 @@ It is possible to override hooks defined in a parent configuration by specifying
 
 ```hcl
 terragrunt = {
-  pre_hooks|post_hooks "name" {
+  pre_hook|post_hook "name" {
     description      = ""                             # Description of the hook
     command          = "command"                      # shell command to execute
     on_commands      = [list of terraform commands]   # optional, default run on all terraform command
@@ -1076,7 +1076,7 @@ terragrunt = {
 
 ```hcl
   # Do terraform get before plan
-  pre_hooks "get-before-plan" {
+  pre_hook "get-before-plan" {
     command          = "terraform"
     arguments        = ["get"]
     on_commands      = ["plan"]
@@ -1084,7 +1084,7 @@ terragrunt = {
   }
 
   # Print the outputs as json after successful apply
-  post_hooks "print-json-output" {
+  post_hook "print-json-output" {
     command          = "terraform"
     arguments        = ["output", "-json"]
     on_commands      = ["apply"]

--- a/README.md
+++ b/README.md
@@ -986,13 +986,13 @@ terragrunt = {
   assume_role = [
     "arn:aws:iam::9999999999999:role/read-write",
     "arn:aws:iam::9999999999999:role/read-only",
-    "error",
+    "",
   ]
 }
 ```
 
-Then, terragrunt will try to assume the roles until it succeeded. Note that the last role could be optionally set to `error` to ensure that at least one role
-is satisfied. If there is no `error` at the end, the process will continue with the user original credentials.
+Then, terragrunt will try to assume the roles until it succeeded. Note that the last role could be optionally set to an empty string to ensure that at least one role
+is satisfied. Empty strings means to continue with the user current role.
 
 The `assume_role` configuration could be defined in any terragrunt configuration files. If it is defined at several level, the leaf configuration will prevail.
 

--- a/_docs/migration_guides/upgrading_to_terragrunt_0.12.x.md
+++ b/_docs/migration_guides/upgrading_to_terragrunt_0.12.x.md
@@ -68,8 +68,8 @@ Note: when switching from Terragrunt v0.11.x to v0.12.x, you also need to change
 Remove any `lock { ... }` blocks from your Terragrunt configurations, as these are no longer supported.
 
 If you were storing remote state in S3 and relying on DynamoDB as a locking mechanism, Terraform now supports that
-natively. To enable it, simply add the `lock_table` parameter to your S3 backend configuration. If you configure
-your S3 backend using Terragrunt, then Terragrunt will automatically create the `lock_table` for you if that table
+natively. To enable it, simply add the `dynamodb_table` parameter to your S3 backend configuration. If you configure
+your S3 backend using Terragrunt, then Terragrunt will automatically create the `dynamodb_table` for you if that table
 doesn't already exist:
 
 ```hcl
@@ -85,7 +85,7 @@ terragrunt = {
 
       # Tell Terraform to do locking using DynamoDB. Terragrunt will automatically
       # create this table for you if it doesn't already exist.
-      lock_table = "my-lock-table"
+      dynamodb_table = "my-lock-table"
     }
   }
 }
@@ -111,7 +111,7 @@ terragrunt = {
 
       # Tell Terraform to do locking using DynamoDB. Terragrunt will automatically
       # create this table for you if it doesn't already exist.
-      lock_table = "my-lock-table"
+      dynamodb_table = "my-lock-table"
     }
   }
 

--- a/cli/args.go
+++ b/cli/args.go
@@ -184,6 +184,16 @@ func filterVarsAndVarFiles(command string, terragruntOptions *options.Terragrunt
 	return filtered, nil
 }
 
+func extractVarArgs() []string {
+	var commandLineArgs []string
+	for i := range os.Args {
+		if os.Args[i] == "-var" {
+			commandLineArgs = append(commandLineArgs, os.Args[i:i+2]...)
+		}
+	}
+	return commandLineArgs
+}
+
 // Return a copy of the given args with all Terragrunt-specific args removed
 func filterTerragruntArgs(args []string) []string {
 	out := []string{}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -279,6 +279,11 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (err error) {
 		if err != nil {
 			return err
 		}
+
+		// We call again the parsing of arguments to be sure that supplied parameters overrides others
+		// There is a corner case when initializing map variables from command line
+		filterVarsAndVarFiles(actualCommand.Command, terragruntOptions, extractVarArgs())
+
 		args = append(args, extraArgs...)
 		if commandLength <= len(terragruntOptions.TerraformCliArgs) {
 			args = append(args, terragruntOptions.TerraformCliArgs[commandLength:]...)
@@ -339,7 +344,11 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (err error) {
 		for i := range roles {
 			role := strings.TrimSpace(roles[i])
 			if role == "" {
-				terragruntOptions.Logger.Notice("Not assuming any role, continuing with the current user credentials", role)
+				listOfRoles := strings.Join(roles[:i], ", ")
+				if listOfRoles != "" {
+					listOfRoles = " from " + listOfRoles
+				}
+				terragruntOptions.Logger.Warningf("Not assuming any role%s, continuing with the current user credentials", listOfRoles)
 				roleAssumed = true
 				break
 			}

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 
 	"github.com/coveo/gotemplate/utils"
 	"github.com/fatih/color"
@@ -143,7 +141,7 @@ const DEFAULT_TERRAFORM_VERSION_CONSTRAINT = ">= v0.9.3"
 const TERRAFORM_EXTENSION_GLOB = "*.tf"
 
 var terragruntVersion string
-var terragruntRunId string
+var terragruntRunID string
 var terraformVersion string
 
 // Create the Terragrunt CLI App
@@ -175,11 +173,11 @@ func CreateTerragruntCli(version string, writer io.Writer, errwriter io.Writer) 
 func runApp(cliContext *cli.Context) (finalErr error) {
 	defer errors.Recover(func(cause error) { finalErr = cause })
 
-	terragruntRunId = fmt.Sprint(xid.New())
+	terragruntRunID = fmt.Sprint(xid.New())
 
-	os.Setenv("TERRAGRUNT_CACHE_FOLDER", util.GetTempDownloadFolder("terragrunt-cache"))
-	os.Setenv("TERRAGRUNT_ARGS", strings.Join(os.Args, " "))
-	os.Setenv("TERRAGRUNT_RUN_ID", terragruntRunId)
+	os.Setenv(options.EnvCacheFolder, util.GetTempDownloadFolder("terragrunt-cache"))
+	os.Setenv(options.EnvArgs, strings.Join(os.Args, " "))
+	os.Setenv(options.EnvRunID, terragruntRunID)
 
 	terragruntOptions, err := ParseTerragruntOptions(cliContext)
 	if err != nil {
@@ -243,12 +241,22 @@ var runHandler func(*options.TerragruntOptions, *config.TerragruntConfig) error
 
 // Run Terragrunt with the given options and CLI args. This will forward all the args directly to Terraform, enforcing
 // best practices along the way.
-func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) {
+func runTerragrunt(terragruntOptions *options.TerragruntOptions) (err error) {
 	terragruntOptions.IgnoreRemainingInterpolation = true
 	conf, err := config.ReadTerragruntConfig(terragruntOptions)
 	if err != nil {
 		return err
 	}
+
+	sourceURL, hasSourceURL := getTerraformSourceURL(terragruntOptions, conf)
+	if sourceURL == "" {
+		sourceURL = terragruntOptions.WorkingDir
+	}
+	if sourceURL, err = util.CanonicalPath(sourceURL, ""); err != nil {
+		return err
+	}
+	terragruntOptions.Env[options.EnvLaunchFolder] = terragruntOptions.WorkingDir
+	terragruntOptions.Env[options.EnvSourceFolder] = sourceURL
 
 	// If runHandler has been specified, we bypass the planned execution and defer the control // to the handler
 	if runHandler != nil {
@@ -267,7 +275,11 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) 
 		// Options must be inserted after command but before the other args command is either 1 word or 2 words
 		var args []string
 		args = append(args, terragruntOptions.TerraformCliArgs[:commandLength]...)
-		args = append(args, filterTerraformExtraArgs(terragruntOptions, conf)...)
+		extraArgs, err := conf.ExtraArguments(sourceURL)
+		if err != nil {
+			return err
+		}
+		args = append(args, extraArgs...)
 		if commandLength <= len(terragruntOptions.TerraformCliArgs) {
 			args = append(args, terragruntOptions.TerraformCliArgs[commandLength:]...)
 		}
@@ -276,17 +288,13 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) 
 
 	conf.SubstituteAllVariables(terragruntOptions, false)
 
-	// Copy the deployment files to the working directory
-	sourceURL, hasSourceURL := getTerraformSourceURL(terragruntOptions, conf)
-	if sourceURL == "" {
-		sourceURL = terragruntOptions.WorkingDir
-	}
-
 	if conf.Uniqueness != nil {
 		// If uniqueness_criteria has been defined, we set it in the options to ensure that
 		// we use distinct folder based on this criteria
 		terragruntOptions.Uniqueness = *conf.Uniqueness
 	}
+
+	// Copy the deployment files to the working directory
 	terraformSource, err := processTerraformSource(sourceURL, terragruntOptions)
 	if err != nil {
 		return err
@@ -302,7 +310,7 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) 
 	// Import the required files in the temporary folder and copy the temporary imported file in the
 	// working folder. We did not put them directly into the folder because terraform init would complain
 	// if there are already terraform files in the target folder
-	if _, err := conf.ImportFiles.Run(); err != nil {
+	if _, err := conf.ImportFiles.Run(nil); err != nil {
 		return err
 	}
 
@@ -346,12 +354,12 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) 
 		}
 	}
 
-	terragruntOptions.Env["TERRAGRUNT_COMMAND"] = terragruntOptions.TerraformCliArgs[0]
+	terragruntOptions.Env[options.EnvCommand] = terragruntOptions.TerraformCliArgs[0]
 	if actualCommand.Extra != nil {
-		terragruntOptions.Env["TERRAGRUNT_EXTRA_COMMAND"] = actualCommand.Command
+		terragruntOptions.Env[options.EnvExtraCommand] = actualCommand.Command
 	}
-	terragruntOptions.Env["TERRAGRUNT_VERSION"] = terragruntVersion
-	terragruntOptions.Env["TERRAFORM_VERSION"] = terraformVersion
+	terragruntOptions.Env[options.EnvVersion] = terragruntVersion
+	terragruntOptions.Env[options.EnvTFVersion] = terraformVersion
 
 	// Temporary make the command behave as another command to initialize the folder properly
 	// (to be sure that the remote state file get initialized)
@@ -384,7 +392,7 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) 
 	terragruntOptions.Env["PATH"] = fmt.Sprintf("%s%c%s", filepath.Join(terraformSource.WorkingDir, config.TerragruntScriptFolder), filepath.ListSeparator, terragruntOptions.Env["PATH"])
 
 	// Executing the pre-hooks commands that should be ran before init state if there are
-	if _, err = conf.PreHooks.Filter(config.BeforeInitState).Run(); err != nil {
+	if _, err = conf.PreHooks.Filter(config.BeforeInitState).Run(nil); err != nil {
 		return err
 	}
 
@@ -396,32 +404,29 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) 
 	}
 
 	// Executing the pre-hooks that should be ran after init state if there are
-	if _, err = conf.PreHooks.Filter(config.AfterInitState).Run(); err != nil {
+	if _, err = conf.PreHooks.Filter(config.AfterInitState).Run(nil); err != nil {
 		return err
 	}
 
 	defer func() {
 		// If there is an error but it is in fact a plan status, we run the post hooks normally
-		_, planStatusError := result.(errors.PlanWithChanges)
+		_, planStatusError := err.(errors.PlanWithChanges)
 
 		// Executing the post-hooks commands if there are and there is no error
-		if result == nil || planStatusError {
-			if _, err := conf.PostHooks.Run(); err != nil {
-				result = err
-			}
+		status := err
+		if planStatusError {
+			status = nil
+		}
+		if _, errHook := conf.PostHooks.Run(status); errHook != nil {
+			err = errHook
 		}
 	}()
 
 	// We define a filter to trap plan exit code that are not real error
 	filterPlanError := func(err error, command string) error {
-		if err == nil || command != "plan" {
-			return err
-		}
-		if exiterr, ok := errors.Unwrap(err).(*exec.ExitError); ok {
+		if exitCode, err := shell.GetExitCode(err); err == nil && command == "plan" && exitCode == errors.CHANGE_EXIT_CODE {
 			// For plan, an error with exit code 2 should not be considered as a real error
-			if exiterr.Sys().(syscall.WaitStatus).ExitStatus() == errors.CHANGE_EXIT_CODE {
-				return errors.PlanWithChanges{}
-			}
+			return errors.PlanWithChanges{}
 		}
 		return err
 	}
@@ -467,6 +472,12 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (result error) 
 	}
 	err = cmd.Run()
 
+	exitCode, errCode := shell.GetExitCode(err)
+	if errCode != nil {
+		exitCode = -1
+	}
+	terragruntOptions.SetStatus(exitCode, err)
+
 	return filterPlanError(err, actualCommand.Command)
 }
 
@@ -497,7 +508,7 @@ func runMultiModuleCommand(command string, terragruntOptions *options.Terragrunt
 
 // A quick sanity check that calls `terraform get` to download modules, if they aren't already downloaded.
 func downloadModules(terragruntOptions *options.TerragruntOptions) error {
-	switch firstArg(terragruntOptions.TerraformCliArgs) {
+	switch util.IndexOrDefault(terragruntOptions.TerraformCliArgs, 0, "") {
 	case "apply", "destroy", "graph", "output", "plan", "show", "taint", "untaint", "validate":
 		shouldDownload, err := shouldDownloadModules(terragruntOptions)
 		if err != nil {
@@ -529,7 +540,7 @@ func shouldDownloadModules(terragruntOptions *options.TerragruntOptions) (bool, 
 func configureRemoteState(remoteState *remote.RemoteState, terragruntOptions *options.TerragruntOptions) error {
 	// We only configure remote state for the commands that use the tfstate files. We do not configure it for
 	// commands such as "get" or "version".
-	if util.ListContainsElement(TERRAFORM_COMMANDS_THAT_USE_STATE, firstArg(terragruntOptions.TerraformCliArgs)) {
+	if util.ListContainsElement(TERRAFORM_COMMANDS_THAT_USE_STATE, util.IndexOrDefault(terragruntOptions.TerraformCliArgs, 0, "")) {
 		return remoteState.ConfigureRemoteState(terragruntOptions)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -314,7 +314,7 @@ func ParseConfigFile(terragruntOptions *options.TerragruntOptions, include Inclu
 }
 
 var configFiles = make(map[string]*TerragruntConfig)
-var hookWarningGiven bool
+var hookWarningGiven, lockWarningGiven bool
 
 // Parse the Terragrunt config contained in the given string.
 func parseConfigString(configString string, terragruntOptions *options.TerragruntOptions, include IncludeConfig) (config *TerragruntConfig, err error) {
@@ -331,6 +331,14 @@ func parseConfigString(configString string, terragruntOptions *options.Terragrun
 		// We should issue this warning only once
 		hookWarningGiven = true
 		terragruntOptions.Logger.Warning("pre_hooks/post_hooks are deprecated, please use pre_hook/post_hook instead")
+	}
+
+	before = configString
+	configString = strings.Replace(configString, "lock_table", "dynamodb_table", -1)
+	if !lockWarningGiven && before != configString {
+		// We should issue this warning only once
+		lockWarningGiven = true
+		terragruntOptions.Logger.Warning("lock_table is deprecated, please use dynamodb_table instead")
 	}
 
 	terragruntConfigFile, err := parseConfigStringAsTerragruntConfigFile(configString, include.Path)

--- a/config/config.go
+++ b/config/config.go
@@ -79,8 +79,8 @@ func (tcf *TerragruntConfigFile) convertToTerragruntConfig(terragruntOptions *op
 	case nil:
 		break
 	case string:
-		// A single role is specified, we convert it in an array of roles ending with error if the role cannot be assumed
-		tcf.AssumeRole = []string{role, "error"}
+		// A single role is specified, we convert it in an array of roles
+		tcf.AssumeRole = []string{role}
 	case []interface{}:
 		// We convert the array to an array of string
 		roles := make([]string, len(role))

--- a/config/extension_base_list.go
+++ b/config/extension_base_list.go
@@ -146,23 +146,35 @@ func (list GenericItemList) Enabled() GenericItemList {
 }
 
 // Run execute the content of the list
-func (list GenericItemList) Run(args ...interface{}) (result []interface{}, err error) {
+func (list GenericItemList) Run(status error, args ...interface{}) (result []interface{}, err error) {
 	if len(list) == 0 {
 		return
 	}
 
 	list.sort()
 
+	var errs errorArray
 	for _, item := range list {
 		iItem := IGenericItem(&item)
-		var temp interface{}
+		if (status != nil || len(errs) > 0) && !iItem.ignoreError() {
+			continue
+		}
 		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
-		if temp, err = iItem.run(args...); err != nil {
-			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)
-			return
+		temp, currentErr := iItem.run(args...)
+		if currentErr != nil {
+			errs = append(errs, fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), currentErr))
 		}
+		iItem.setState(currentErr)
 		result = append(result, temp)
+	}
+	switch len(errs) {
+	case 0:
+		break
+	case 1:
+		err = errs[0]
+	default:
+		err = errs
 	}
 	return
 }

--- a/config/extension_extra_args.go
+++ b/config/extension_extra_args.go
@@ -2,13 +2,18 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
+
+	"github.com/gruntwork-io/terragrunt/options"
+	"github.com/gruntwork-io/terragrunt/util"
 )
 
 // TerraformExtraArguments sets a list of arguments to pass to Terraform if command fits any in the `Commands` list
 type TerraformExtraArguments struct {
 	TerragruntExtensionBase `hcl:",squash"`
 
+	Source           string   `hcl:"source"`
 	Arguments        []string `hcl:"arguments"`
 	Vars             []string `hcl:"vars"`
 	RequiredVarFiles []string `hcl:"required_var_files"`
@@ -42,4 +47,102 @@ func (list TerraformExtraArgumentsList) sort() TerraformExtraArgumentsList { ret
 // Merge elements from an imported list to the current list
 func (list *TerraformExtraArgumentsList) Merge(imported TerraformExtraArgumentsList) {
 	list.merge(imported, mergeModePrepend, list.argName())
+}
+
+// Filter applies extra_arguments to the current configuration
+func (list TerraformExtraArgumentsList) Filter(source string) ([]string, error) {
+	if len(list) == 0 {
+		return nil, nil
+	}
+
+	config := ITerraformExtraArguments(&list[0]).config()
+	terragruntOptions := config.options
+
+	out := []string{}
+	cmd := util.IndexOrDefault(terragruntOptions.TerraformCliArgs, 0, "")
+
+	folders := []string{terragruntOptions.WorkingDir}
+	if terragruntOptions.WorkingDir != source {
+		folders = append(folders, source)
+	}
+
+	for _, arg := range list.Enabled() {
+		currentCommandIncluded := util.ListContainsElement(arg.Commands, cmd)
+
+		if currentCommandIncluded {
+			out = append(out, arg.Arguments...)
+		}
+
+		folders := folders
+		logger := arg.logger()
+
+		if arg.Source != "" {
+			arg.Source = SubstituteVars(arg.Source, terragruntOptions)
+			sourceFolder, err := util.GetSource(arg.Source, filepath.Dir(arg.config().Path), logger)
+			if err != nil {
+				if len(arg.RequiredVarFiles) > 0 {
+					return nil, err
+				}
+				logger.Warningf("%s: %s doesn't exist", arg.Name, arg.Source)
+			}
+			folders = []string{sourceFolder}
+		}
+
+		// We first process all the -var because they have precedence over -var-file
+		// If vars is specified, add -var <key=value> for each specified key
+		keyFunc := func(key string) string { return strings.Split(key, "=")[0] }
+		varList := util.RemoveDuplicatesFromList(arg.Vars, true, keyFunc)
+		variablesExplicitlyProvided := terragruntOptions.VariablesExplicitlyProvided()
+		for _, varDef := range varList {
+			varDef = SubstituteVars(varDef, terragruntOptions)
+			if key, value, err := util.SplitEnvVariable(varDef); err != nil {
+				terragruntOptions.Logger.Warningf("-var ignored in %v: %v", arg.Name, err)
+			} else {
+				if util.ListContainsElement(variablesExplicitlyProvided, key) {
+					continue
+				}
+				terragruntOptions.SetVariable(key, value, options.VarParameter)
+			}
+			if currentCommandIncluded {
+				out = append(out, "-var", varDef)
+			}
+		}
+
+		// If RequiredVarFiles is specified, add -var-file=<file> for each specified files
+		for _, pattern := range util.RemoveDuplicatesFromListKeepLast(arg.RequiredVarFiles) {
+			files := config.globFiles(pattern, folders...)
+			if len(files) == 0 {
+				return nil, fmt.Errorf("%s: No file matches %s", arg.name(), pattern)
+			}
+			for _, file := range files {
+				terragruntOptions.Logger.Info("Importing", file)
+				if err := terragruntOptions.ImportVariablesFromFile(file, options.VarFile); err != nil {
+					return nil, err
+				}
+				if currentCommandIncluded {
+					out = append(out, fmt.Sprintf("-var-file=%s", file))
+				}
+			}
+		}
+
+		// If OptionalVarFiles is specified, check for each file if it exists and if so, add -var-file=<file>
+		// It is possible that many files resolve to the same path, so we remove duplicates.
+		for _, pattern := range util.RemoveDuplicatesFromListKeepLast(arg.OptionalVarFiles) {
+			for _, file := range config.globFiles(pattern, folders...) {
+				if util.FileExists(file) {
+					if currentCommandIncluded {
+						out = append(out, fmt.Sprintf("-var-file=%s", file))
+					}
+					terragruntOptions.Logger.Info("Importing", file)
+					if err := terragruntOptions.ImportVariablesFromFile(file, options.VarFile); err != nil {
+						return nil, err
+					}
+				} else if currentCommandIncluded {
+					terragruntOptions.Logger.Debugf("Skipping var-file %s as it does not exist", file)
+				}
+			}
+		}
+	}
+
+	return out, nil
 }

--- a/config/extension_extra_command.go
+++ b/config/extension_extra_command.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/coveo/gotemplate/utils"
 	"github.com/fatih/color"
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 	logging "github.com/op/go-logging"
@@ -170,7 +171,7 @@ func (list ExtraCommandList) GetVersions() string {
 			var out string
 			if err == nil {
 				c := shell.NewCmd(item.options(), command.Args[0])
-				c = c.Env(fmt.Sprintf("TERRAGRUNT_COMMAND=%s", cmd))
+				c = c.Env(fmt.Sprintf("%s=%s", options.EnvCommand, cmd))
 				c = c.Args(append(command.Args[1:], item.options().WorkingDir)...)
 				c.DisplayCommand = actualCmd
 				out, err = c.Output()

--- a/config/extension_hook.go
+++ b/config/extension_hook.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/coveo/gotemplate/utils"
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 )
@@ -26,6 +27,7 @@ type Hook struct {
 }
 
 func (hook Hook) itemType() (result string) { return HookList{}.argName() }
+func (hook Hook) ignoreError() bool         { return hook.IgnoreError }
 
 func (hook Hook) help() (result string) {
 	if hook.Description != "" {
@@ -50,7 +52,7 @@ func (hook Hook) help() (result string) {
 func (hook *Hook) run(args ...interface{}) (result []interface{}, err error) {
 	logger := hook.logger()
 
-	if len(hook.OnCommands) > 0 && !util.ListContainsElement(hook.OnCommands, hook.options().Env["TERRAGRUNT_COMMAND"]) {
+	if len(hook.OnCommands) > 0 && !util.ListContainsElement(hook.OnCommands, hook.options().Env[options.EnvCommand]) {
 		// The current command is not in the list of command on which the hook should be applied
 		return
 	}

--- a/config/extension_import_files.go
+++ b/config/extension_import_files.go
@@ -83,6 +83,11 @@ func (item *ImportFiles) run(folders ...interface{}) (result []interface{}, err 
 		return
 	}
 
+	if item.Source == "" && len(item.Files) == 0 && len(item.CopyAndRename) == 0 {
+		logger.Debugf("Import file %s skipped, nothing to do", item.Name)
+		return
+	}
+
 	// If no folders are specified, we only copy elements to the working folder
 	if len(folders) == 0 {
 		folders = []interface{}{item.options().WorkingDir}
@@ -305,5 +310,5 @@ func (list ImportFilesList) RunOnModules(terragruntOptions *options.TerragruntOp
 		keys = append(keys, key)
 	}
 
-	return list.Run(keys...)
+	return list.Run(nil, keys...)
 }

--- a/config/generated_approval_config.go
+++ b/config/generated_approval_config.go
@@ -145,23 +145,35 @@ func (list ApprovalConfigList) Enabled() ApprovalConfigList {
 }
 
 // Run execute the content of the list
-func (list ApprovalConfigList) Run(args ...interface{}) (result []interface{}, err error) {
+func (list ApprovalConfigList) Run(status error, args ...interface{}) (result []interface{}, err error) {
 	if len(list) == 0 {
 		return
 	}
 
 	list.sort()
 
+	var errs errorArray
 	for _, item := range list {
 		iItem := IApprovalConfig(&item)
-		var temp interface{}
+		if (status != nil || len(errs) > 0) && !iItem.ignoreError() {
+			continue
+		}
 		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
-		if temp, err = iItem.run(args...); err != nil {
-			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)
-			return
+		temp, currentErr := iItem.run(args...)
+		if currentErr != nil {
+			errs = append(errs, fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), currentErr))
 		}
+		iItem.setState(currentErr)
 		result = append(result, temp)
+	}
+	switch len(errs) {
+	case 0:
+		break
+	case 1:
+		err = errs[0]
+	default:
+		err = errs
 	}
 	return
 }

--- a/config/generated_extra_args.go
+++ b/config/generated_extra_args.go
@@ -145,23 +145,35 @@ func (list TerraformExtraArgumentsList) Enabled() TerraformExtraArgumentsList {
 }
 
 // Run execute the content of the list
-func (list TerraformExtraArgumentsList) Run(args ...interface{}) (result []interface{}, err error) {
+func (list TerraformExtraArgumentsList) Run(status error, args ...interface{}) (result []interface{}, err error) {
 	if len(list) == 0 {
 		return
 	}
 
 	list.sort()
 
+	var errs errorArray
 	for _, item := range list {
 		iItem := ITerraformExtraArguments(&item)
-		var temp interface{}
+		if (status != nil || len(errs) > 0) && !iItem.ignoreError() {
+			continue
+		}
 		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
-		if temp, err = iItem.run(args...); err != nil {
-			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)
-			return
+		temp, currentErr := iItem.run(args...)
+		if currentErr != nil {
+			errs = append(errs, fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), currentErr))
 		}
+		iItem.setState(currentErr)
 		result = append(result, temp)
+	}
+	switch len(errs) {
+	case 0:
+		break
+	case 1:
+		err = errs[0]
+	default:
+		err = errs
 	}
 	return
 }

--- a/config/generated_extra_command.go
+++ b/config/generated_extra_command.go
@@ -145,23 +145,35 @@ func (list ExtraCommandList) Enabled() ExtraCommandList {
 }
 
 // Run execute the content of the list
-func (list ExtraCommandList) Run(args ...interface{}) (result []interface{}, err error) {
+func (list ExtraCommandList) Run(status error, args ...interface{}) (result []interface{}, err error) {
 	if len(list) == 0 {
 		return
 	}
 
 	list.sort()
 
+	var errs errorArray
 	for _, item := range list {
 		iItem := IExtraCommand(&item)
-		var temp interface{}
+		if (status != nil || len(errs) > 0) && !iItem.ignoreError() {
+			continue
+		}
 		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
-		if temp, err = iItem.run(args...); err != nil {
-			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)
-			return
+		temp, currentErr := iItem.run(args...)
+		if currentErr != nil {
+			errs = append(errs, fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), currentErr))
 		}
+		iItem.setState(currentErr)
 		result = append(result, temp)
+	}
+	switch len(errs) {
+	case 0:
+		break
+	case 1:
+		err = errs[0]
+	default:
+		err = errs
 	}
 	return
 }

--- a/config/generated_hooks.go
+++ b/config/generated_hooks.go
@@ -145,23 +145,35 @@ func (list HookList) Enabled() HookList {
 }
 
 // Run execute the content of the list
-func (list HookList) Run(args ...interface{}) (result []interface{}, err error) {
+func (list HookList) Run(status error, args ...interface{}) (result []interface{}, err error) {
 	if len(list) == 0 {
 		return
 	}
 
 	list.sort()
 
+	var errs errorArray
 	for _, item := range list {
 		iItem := IHook(&item)
-		var temp interface{}
+		if (status != nil || len(errs) > 0) && !iItem.ignoreError() {
+			continue
+		}
 		iItem.logger().Infof("Running %s (%s): %s", iItem.itemType(), iItem.id(), iItem.name())
 		iItem.normalize()
-		if temp, err = iItem.run(args...); err != nil {
-			err = fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), err)
-			return
+		temp, currentErr := iItem.run(args...)
+		if currentErr != nil {
+			errs = append(errs, fmt.Errorf("Error while executing %s(%s): %v", iItem.itemType(), iItem.id(), currentErr))
 		}
+		iItem.setState(currentErr)
 		result = append(result, temp)
+	}
+	switch len(errs) {
+	case 0:
+		break
+	case 1:
+		err = errs[0]
+	default:
+		err = errs
 	}
 	return
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 27b2010470f725542ebca50036ae38a9e2ea791d60e698d1c336b75ccd6c75cd
-updated: 2018-02-26T11:49:28.607709-05:00
+updated: 2018-03-05T12:42:26.528286-05:00
 imports:
 - name: github.com/agext/levenshtein
   version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
@@ -22,7 +22,7 @@ imports:
 - name: github.com/armon/go-radix
   version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
 - name: github.com/aws/aws-sdk-go
-  version: f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d
+  version: aace5875a5c3b85a3902c6d72b9caed301d64cce
   subpackages:
   - aws
   - aws/awserr
@@ -63,13 +63,13 @@ imports:
 - name: github.com/bgentry/speakeasy
   version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
 - name: github.com/blang/semver
-  version: a088618caaf34f5392024fc3386143873033fbea
+  version: c5e971dbed7850a93c23aa6ff69db5771d8e23b3
 - name: github.com/cheekybits/genny
   version: 9127e812e1e9e501ce899a18121d316ecb52e4ba
   subpackages:
   - generic
 - name: github.com/coveo/gotemplate
-  version: 0b108a30d26a73b6c6753ed68c7135d77c03d849
+  version: 4df12337764388cd6eff5f33399d4431dd615d0b
   subpackages:
   - errors
   - hcl
@@ -83,21 +83,21 @@ imports:
 - name: github.com/fatih/color
   version: 507f6050b8568533fb3f5504de8e5205fa62a114
 - name: github.com/go-errors/errors
-  version: 3afebba5a48dbc89b574d890b6b34d9ee10b4785
+  version: a6af135bd4e28680facf08a3d206b454abc877a4
 - name: github.com/go-ini/ini
-  version: 32e4be5f41bb918afb6e37c07426e2ddbcb6647e
+  version: e88632e2fbbd517932de8a0af39beb223b03ae35
 - name: github.com/hashicorp/errwrap
   version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
 - name: github.com/hashicorp/go-cleanhttp
   version: d5fe4b57a186c716b0e00b8c301cbd9b4182694d
 - name: github.com/hashicorp/go-getter
-  version: da1332ad370dd543e363ee5ad0098987f60a429a
+  version: 64040d90d4ab861e7e833d689dc76a0f176d8dec
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-multierror
   version: b7773ae218740a7be65057fc60b366a49b538a44
 - name: github.com/hashicorp/go-uuid
-  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
+  version: 27454136f0364f2d44b1276c552d69105cf8c498
 - name: github.com/hashicorp/go-version
   version: 4fe82ae3040f80a03d04d2cccb5606a626b8e1ee
 - name: github.com/hashicorp/hcl
@@ -112,7 +112,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hashicorp/hcl2
-  version: 4719b76b5235739a3aa76131739a62aec6192e7d
+  version: be66a72aa86d789b518ef778293624d56b5b633f
   subpackages:
   - gohcl
   - hcl
@@ -205,7 +205,7 @@ imports:
 - name: github.com/urfave/cli
   version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: github.com/zclconf/go-cty
-  version: 26c3df5df72fc4bb0f323e36b752d7869ccc5d3a
+  version: 49fa5e03c418f95f78684c91e155af06aa901a32
   subpackages:
   - cty
   - cty/convert
@@ -215,7 +215,7 @@ imports:
   - cty/json
   - cty/set
 - name: golang.org/x/crypto
-  version: beaf6a35706e5032ae4c3fcf342c663c069f44d2
+  version: 91a49db82a88618983a78a06c1cbd4e00ab749ab
   subpackages:
   - bcrypt
   - blowfish
@@ -229,17 +229,17 @@ imports:
   - pbkdf2
   - scrypt
 - name: golang.org/x/net
-  version: cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb
+  version: 22ae77b79946ea320088417e4d50825671d82d57
   subpackages:
   - html
   - html/atom
   - idna
 - name: golang.org/x/sys
-  version: f6cff0780e542efa0c8e864dc8fa522808f6a598
+  version: dd2ff4accc098aceecb86b36eaa7829b2a17b1c9
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 27420a1a391f5504f73155051cd274311bf70883
+  version: b7ef84aaf62aa3e70962625c80a571ae7c17cb40
   subpackages:
   - secure/bidirule
   - transform

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gruntwork-io/terragrunt/cli"
 	"github.com/gruntwork-io/terragrunt/errors"
+	"github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/shell"
 	"github.com/gruntwork-io/terragrunt/util"
 )
@@ -32,7 +33,7 @@ func checkForErrorsAndExit(err error) {
 
 		if _, ok := errors.Unwrap(err).(errors.PlanWithChanges); !ok {
 			// Plan status are not considred as an error
-			if os.Getenv("TERRAGRUNT_DEBUG") != "" {
+			if os.Getenv(options.EnvDebug) != "" {
 				logger.Error(errors.PrintErrorWithStackTrace(err))
 			} else {
 				logger.Error(err)

--- a/options/environment_variables.go
+++ b/options/environment_variables.go
@@ -1,0 +1,33 @@
+package options
+
+// All environment variables that could be used to configure Terragrunt
+const (
+	EnvCacheFolder  = "TERRAGRUNT_CACHE_FOLDER"  // Used to configure the cache folder (optional, default determined by os temp folder)
+	EnvConfig       = "TERRAGRUNT_CONFIG"        // Used to configure the location of the Terragrunt configuration file (optional, default terraform.tfvars in the current folder)
+	EnvDebug        = "TERRAGRUNT_DEBUG"         // Used to enable Terragrunt debug mode
+	EnvFlushDelay   = "TERRAGRUNT_FLUSH_DELAY"   // Used to configure the flush delay on long -all operation (default 60s)
+	EnvLoggingLevel = "TERRAGRUNT_LOGGING_LEVEL" // Used to configure the current logging level
+	EnvSource       = "TERRAGRUNT_SOURCE"        // Used to configure the location of the Terraform source folder (optional, default determined by source in the terragrunt.terraform object
+	EnvTFPath       = "TERRAGRUNT_TFPATH"        // Used to configure the path to the terraform command (optional, default terraform)
+	EnvWorkers      = "TERRAGRUNT_WORKERS"       // Used to configure the maximum number of concurrent workers (optional)
+)
+
+// All environment variables that are published during Terragrunt execution to share current context during shell execution
+const (
+	EnvArgs         = "TERRAGRUNT_ARGS"          // Used to publish the supplied arguments to the Terragrunt command
+	EnvCommand      = "TERRAGRUNT_COMMAND"       // Used to publish the current Terragrunt command
+	EnvExtraCommand = "TERRAGRUNT_EXTRA_COMMAND" // Used to publish the name of the actual running command
+	EnvLaunchFolder = "TERRAGRUNT_LAUNCH_FOLDER" // Used to publish the launch folder from where the Terragrunt operation has been launched
+	EnvRunID        = "TERRAGRUNT_RUN_ID"        // Used to publish the current run id, this is unique to each Terragrunt execution, but can be used to link -all operations
+	EnvSourceFolder = "TERRAGRUNT_SOURCE_FOLDER" // Used to publish the current Terraform source folder used
+	EnvTFVersion    = "TERRAFORM_VERSION"        // Used to publish the Terraform version
+	EnvVersion      = "TERRAGRUNT_VERSION"       // Used to publish the Terragrunt version
+)
+
+// All environment variables that are published during Terragrunt execution to indicate the current execution status
+const (
+	EnvLastError  = "TERRAGRUNT_LAST_ERROR"  // Used to publish the last executed command error message
+	EnvLastStatus = "TERRAGRUNT_LAST_STATUS" // Used to publish the last executed command exit code
+	EnvError      = "TERRAGRUNT_ERROR"       // Used to publish the cumulated command error if there are
+	EnvStatus     = "TERRAGRUNT_STATUS"      // Used to publish the status of the execution flow
+)

--- a/options/options.go
+++ b/options/options.go
@@ -279,6 +279,11 @@ func (terragruntOptions *TerragruntOptions) Printf(format string, args ...interf
 
 // SetVariable overwrites the value in the variables map only if the source is more significant than the original value
 func (terragruntOptions *TerragruntOptions) SetVariable(key string, value interface{}, source VariableSource) {
+	if strings.Contains(key, ".") {
+		keys := strings.Split(key, ".")
+		key = keys[0]
+		value = util.ConvertToMap(value, keys[1:]...)
+	}
 	target := terragruntOptions.Variables[key]
 	oldMap, oldIsMap := target.Value.(map[string]interface{})
 	newMap, newIsMap := value.(map[string]interface{})

--- a/remote/remote_state_s3.go
+++ b/remote/remote_state_s3.go
@@ -21,7 +21,7 @@ type RemoteStateConfigS3 struct {
 	Key       string `mapstructure:"key"`
 	Region    string `mapstructure:"region"`
 	Profile   string `mapstructure:"profile"`
-	LockTable string `mapstructure:"lock_table"`
+	LockTable string `mapstructure:"dynamodb_table"`
 }
 
 const MAX_RETRIES_WAITING_FOR_S3_BUCKET = 12

--- a/shell/approval_handler.go
+++ b/shell/approval_handler.go
@@ -39,7 +39,7 @@ func RunCommandToApprove(cmd *exec.Cmd, expectedStatements []string, completedSt
 		return goErrors.New("Waited 30 seconds for input prompt. Did not get it.")
 	}
 
-	if isDashAllQuery(terragruntOptions.Env["TERRAGRUNT_ARGS"]) {
+	if isDashAllQuery(terragruntOptions.Env[options.EnvArgs]) {
 		fmt.Println(stdOutInterceptor.GetBuffer())
 	}
 

--- a/test/fixture-download/local-with-backend/terraform.tfvars
+++ b/test/fixture-download/local-with-backend/terraform.tfvars
@@ -8,12 +8,13 @@ terragrunt = {
   # Configure Terragrunt to automatically store tfstate files in an S3 bucket
   remote_state {
     backend = "s3"
+
     config {
-      encrypt = true
-      bucket = "__FILL_IN_BUCKET_NAME__"
-      key = "terraform.tfstate"
-      region = "us-west-2"
-      lock_table = "__FILL_IN_LOCK_TABLE_NAME__"
+      encrypt        = true
+      bucket         = "__FILL_IN_BUCKET_NAME__"
+      key            = "terraform.tfstate"
+      region         = "us-west-2"
+      dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
     }
   }
 }

--- a/test/fixture-download/remote-with-backend/terraform.tfvars
+++ b/test/fixture-download/remote-with-backend/terraform.tfvars
@@ -8,12 +8,13 @@ terragrunt = {
   # Configure Terragrunt to automatically store tfstate files in an S3 bucket
   remote_state {
     backend = "s3"
+
     config {
-      encrypt = true
-      bucket = "__FILL_IN_BUCKET_NAME__"
-      key = "terraform.tfstate"
-      region = "us-west-2"
-      lock_table = "__FILL_IN_LOCK_TABLE_NAME__"
+      encrypt        = true
+      bucket         = "__FILL_IN_BUCKET_NAME__"
+      key            = "terraform.tfstate"
+      region         = "us-west-2"
+      dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
     }
   }
 }

--- a/test/fixture-stack/terraform.tfvars
+++ b/test/fixture-stack/terraform.tfvars
@@ -2,12 +2,13 @@ terragrunt = {
   # Configure Terragrunt to automatically store tfstate files in an S3 bucket
   remote_state {
     backend = "s3"
+
     config {
-      encrypt = true
-      bucket = "__FILL_IN_BUCKET_NAME__"
-      key = "${path_relative_to_include()}/terraform.tfstate"
-      region = "us-west-2"
-      lock_table = "__FILL_IN_LOCK_TABLE_NAME__"
+      encrypt        = true
+      bucket         = "__FILL_IN_BUCKET_NAME__"
+      key            = "${path_relative_to_include()}/terraform.tfstate"
+      region         = "us-west-2"
+      dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
     }
   }
 }

--- a/test/fixture/terraform.tfvars
+++ b/test/fixture/terraform.tfvars
@@ -2,12 +2,13 @@ terragrunt = {
   # Configure Terragrunt to automatically store tfstate files in an S3 bucket
   remote_state {
     backend = "s3"
+
     config {
-      encrypt = true
-      bucket = "__FILL_IN_BUCKET_NAME__"
-      key = "terraform.tfstate"
-      region = "us-west-2"
-      lock_table = "__FILL_IN_LOCK_TABLE_NAME__"
+      encrypt        = true
+      bucket         = "__FILL_IN_BUCKET_NAME__"
+      key            = "terraform.tfstate"
+      region         = "us-west-2"
+      dynamodb_table = "__FILL_IN_LOCK_TABLE_NAME__"
     }
   }
 }

--- a/util/collections.go
+++ b/util/collections.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	goErrors "errors"
 	"fmt"
 	"strings"
 )
@@ -73,4 +74,24 @@ func CommaSeparatedStrings(list []string) string {
 		values = append(values, fmt.Sprintf(`"%s"`, value))
 	}
 	return strings.Join(values, ", ")
+}
+
+// SplitEnvVariable returns the two parts of an environment variable
+func SplitEnvVariable(str string) (key, value string, err error) {
+	variableSplit := strings.SplitN(str, "=", 2)
+
+	if len(variableSplit) == 2 {
+		key, value, err = strings.TrimSpace(variableSplit[0]), variableSplit[1], nil
+	} else {
+		err = goErrors.New(fmt.Sprintf("Invalid variable format %v, should be name=value", str))
+	}
+	return
+}
+
+// IndexOrDefault returns the item at index position or default value if the array is shorter than index
+func IndexOrDefault(list []string, index int, defVal string) string {
+	if len(list) > index {
+		return list[index]
+	}
+	return defVal
 }

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -2,11 +2,19 @@ package util
 
 import "reflect"
 
-// Return the kind of the type or Invalid if value is nil
+// KindOf returns the kind of the type or Invalid if value is nil
 func KindOf(value interface{}) reflect.Kind {
 	valueType := reflect.TypeOf(value)
 	if valueType == nil {
 		return reflect.Invalid
 	}
 	return valueType.Kind()
+}
+
+// ConvertToMap builds a map with the keys supplied
+func ConvertToMap(value interface{}, keys ...string) interface{} {
+	if len(keys) > 0 {
+		return map[string]interface{}{keys[0]: ConvertToMap(value, keys[1:]...)}
+	}
+	return value
 }

--- a/util/reflect_test.go
+++ b/util/reflect_test.go
@@ -1,10 +1,11 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestKindOf(t *testing.T) {
@@ -29,5 +30,29 @@ func TestKindOf(t *testing.T) {
 		actual := KindOf(testCase.value).String()
 		assert.Equal(t, testCase.expected.String(), actual, "For value %v", testCase.value)
 		t.Logf("%v passed", testCase.value)
+	}
+}
+
+func TestConvertToMap(t *testing.T) {
+	type args struct {
+		value interface{}
+		keys  []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{"Simple value", args{1, nil}, 1},
+		{"Simple value", args{1, []string{"a"}}, map[string]interface{}{"a": 1}},
+		{"Simple value", args{1, []string{"a", "b"}}, map[string]interface{}{"a": map[string]interface{}{"b": 1}}},
+		{"Simple value", args{1, []string{"a", "b", "c"}}, map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c": 1}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConvertToMap(tt.args.value, tt.args.keys...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConvertToMap() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Change the behaviour of cascading assume_role, use empty role at the end of the list to allow user to continue with its own credentials
- Terraform deprecated lock_table to replace it by dynamodb_table (without that change, DynamoDB was no longer generated on first usage)
- Refactor constant environment variables to group them together and document them
- Move filterTerraformExtraArgs within extra_arg implementation
- Implement support for importing values from remote source (add source support to extra_arguments)
- Improve the error management (some error were obfuscated)
- Fix a problem causing status of external command to not be returned correctly
- Fix a problem causing ignore_error option on hooks to not working
- Add environment variables during script execution to publish the current and last status of external commands