### PR TITLE
- To avoid error when trying to launch non -all operation in a parent…

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -246,7 +246,7 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (finalStatus er
 		return fmt.Errorf("Folder ignored because %s is present", options.IgnoreFile)
 	}
 
-	if util.FileExists(filepath.Join(terragruntOptions.WorkingDir, options.IgnoreFileNonInteractive)) {
+	if terragruntOptions.NonInteractive && util.FileExists(filepath.Join(terragruntOptions.WorkingDir, options.IgnoreFileNonInteractive)) {
 		return fmt.Errorf("Folder ignored because %s is present", options.IgnoreFileNonInteractive)
 	}
 

--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -242,6 +242,14 @@ var runHandler func(*options.TerragruntOptions, *config.TerragruntConfig) error
 // Run Terragrunt with the given options and CLI args. This will forward all the args directly to Terraform, enforcing
 // best practices along the way.
 func runTerragrunt(terragruntOptions *options.TerragruntOptions) (finalStatus error) {
+	if util.FileExists(filepath.Join(terragruntOptions.WorkingDir, options.IgnoreFile)) {
+		return fmt.Errorf("Folder ignored because %s is present", options.IgnoreFile)
+	}
+
+	if util.FileExists(filepath.Join(terragruntOptions.WorkingDir, options.IgnoreFileNonInteractive)) {
+		return fmt.Errorf("Folder ignored because %s is present", options.IgnoreFileNonInteractive)
+	}
+
 	terragruntOptions.IgnoreRemainingInterpolation = true
 	conf, err := config.ReadTerragruntConfig(terragruntOptions)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -194,12 +194,12 @@ func FindConfigFilesInPath(terragruntOptions *options.TerragruntOptions) ([]stri
 		}
 
 		if info.IsDir() {
-			if util.FileExists(filepath.Join(path, "terragrunt.ignore")) {
+			if util.FileExists(filepath.Join(path, options.IgnoreFile)) {
 				// If we wish to exclude a directory from the *-all commands, we just
 				// have to put an empty file name terragrunt.ignore in the folder
 				return nil
 			}
-			if terragruntOptions.NonInteractive && util.FileExists(filepath.Join(path, "terragrunt-non-interactive.ignore")) {
+			if terragruntOptions.NonInteractive && util.FileExists(filepath.Join(path, options.IgnoreFileNonInteractive)) {
 				// If we wish to exclude a directory from the *-all commands, we just
 				// have to put an empty file name terragrunt-non-interactive.ignore in
 				// the folder

--- a/options/constants.go
+++ b/options/constants.go
@@ -1,0 +1,7 @@
+package options
+
+// Global constants
+const (
+	IgnoreFile               = "terragrunt.ignore"
+	IgnoreFileNonInteractive = "terragrunt-non-interactive.ignore"
+)


### PR DESCRIPTION
… folder with terragrunt.ignore file, we simply return an error at the beginning. That will save a lot of time trying to understand why it is not working when we are wrongly positionned.