### PR TITLE
Always run terraform get -update before terraform init

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -460,6 +460,8 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (finalStatus er
 		return
 	}
 
+	shell.NewTFCmd(terragruntOptions).Args([]string{"get", "-update"}...).WithRetries(3).Output()
+
 	// Configure remote state if required
 	if conf.RemoteState != nil {
 		if err := configureRemoteState(conf.RemoteState, terragruntOptions); stopOnError(err) {


### PR DESCRIPTION
When creating new modules using prehooks, terraform init will fail because these modules haven't been fetched.