### PR TITLE
Fix args eval

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: c03c830bfe54d02870422b370ae1d45b2c54b23b17e6104a28da0073a1ace7ff
-updated: 2019-03-08T10:10:55.11429-05:00
+updated: 2019-03-08T15:17:15.151819-05:00
 imports:
 - name: cloud.google.com/go
   version: 7377f9d353bf3a755e4df421fd87c466f522714f
@@ -88,7 +88,7 @@ imports:
   subpackages:
   - generic
 - name: github.com/coveo/gotemplate
-  version: 57e1c8d949c7f20f172dc2455c7259c099957377
+  version: 1d8000d9759115bc1c74d92e631ef4c77d0ab2c8
   subpackages:
   - collections
   - collections/implementation
@@ -178,7 +178,7 @@ imports:
   - parser
   - scanner
 - name: github.com/hashicorp/terraform
-  version: ac4fff416318bf0915a0ab80e062a99ef3724334
+  version: 057286e5228559722bfc9bf6a03679650358c9d2
   subpackages:
   - config
   - config/hcl2shim

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,18 @@
 hash: c03c830bfe54d02870422b370ae1d45b2c54b23b17e6104a28da0073a1ace7ff
-updated: 2019-02-05T07:26:56.556046091-05:00
+updated: 2019-03-08T10:10:55.11429-05:00
 imports:
+- name: cloud.google.com/go
+  version: 7377f9d353bf3a755e4df421fd87c466f522714f
+  subpackages:
+  - compute/metadata
+  - iam
+  - internal
+  - internal/optional
+  - internal/trace
+  - internal/version
+  - storage
 - name: github.com/agext/levenshtein
-  version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
+  version: 0ded9c86537917af2ff89bc9c78de6bd58477894
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
   subpackages:
@@ -11,8 +21,6 @@ imports:
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/andybalholm/cascadia
   version: 680b6a57bda4f657485ad44bdea42342ead737bc
-- name: github.com/aokoli/goutils
-  version: 41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0
 - name: github.com/apparentlymart/go-cidr
   version: 1755c023625ec3a84979b90841a1ab067ed6c071
   subpackages:
@@ -24,7 +32,7 @@ imports:
 - name: github.com/armon/go-radix
   version: 1a2de0c21c94309923825da3df33a4381872c795
 - name: github.com/aws/aws-sdk-go
-  version: 949cbce4e4443b72f6da12adbeb5d416dd506fbe
+  version: 774132714af4336cfacbde2528d8702d0649f225
   subpackages:
   - aws
   - aws/awserr
@@ -80,7 +88,7 @@ imports:
   subpackages:
   - generic
 - name: github.com/coveo/gotemplate
-  version: fddad3f3f6e08434f3726696bc8116393af6fea0
+  version: 57e1c8d949c7f20f172dc2455c7259c099957377
   subpackages:
   - collections
   - collections/implementation
@@ -101,8 +109,17 @@ imports:
   version: 3f9d52f7176a6927daacff70a3e8d1dc2025c53e
 - name: github.com/go-errors/errors
   version: d98b870cc4e05f1545532a80e9909be8216095b6
+- name: github.com/golang/protobuf
+  version: b5d812f8a3706043e23a9cd5babf2e5423744d30
+  subpackages:
+  - proto
+  - protoc-gen-go/descriptor
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
 - name: github.com/google/go-cmp
-  version: 2248b49eaa8e1c8c0963ee77b40841adbc19d4ca
+  version: c81281657ad99ba22e14fda7c4dfaaf2974c454e
   subpackages:
   - cmp
   - cmp/internal/diff
@@ -110,12 +127,16 @@ imports:
   - cmp/internal/value
 - name: github.com/google/uuid
   version: 064e2069ce9c359c118179501254f67d7d37ba24
+- name: github.com/googleapis/gax-go
+  version: beaecbbdd8af86aa3acf14180d53828ce69400b2
+  subpackages:
+  - v2
 - name: github.com/hashicorp/errwrap
   version: 8a6fb523712970c966eefc6b39ed2c5e74880354
 - name: github.com/hashicorp/go-cleanhttp
   version: e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18
 - name: github.com/hashicorp/go-getter
-  version: 244ff472147290528195500b7d2557620d2d056e
+  version: e1437d0bbb37a1fa61cdb924b034352c823cb89b
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-multierror
@@ -126,6 +147,10 @@ imports:
   version: 4f571afc59f3043a65f8fe6bf46d887b10a01d43
 - name: github.com/hashicorp/go-version
   version: d40cf49b3a77bba84a7afdbd7f1dc295d114efb1
+- name: github.com/hashicorp/golang-lru
+  version: 7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c
+  subpackages:
+  - simplelru
 - name: github.com/hashicorp/hcl
   version: 65a6292f0157eff210d03ed1bf6c59b190b8b906
   subpackages:
@@ -138,7 +163,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hashicorp/hcl2
-  version: 89dbc5eb3d9ed3b44b5a60bda31dc68c52f496bb
+  version: fdf8e232b64f68d5335fa1be449b0160dadacdb5
   subpackages:
   - gohcl
   - hcl
@@ -147,7 +172,7 @@ imports:
   - hclparse
   - hclwrite
 - name: github.com/hashicorp/hil
-  version: 59d7c1fee952b29ee4c9ceba65c9d02ee28eb281
+  version: 97b3a9cdfa9349086cfad7ea2fe3165bfe3cbf63
   subpackages:
   - ast
   - parser
@@ -173,13 +198,15 @@ imports:
 - name: github.com/huandu/xstrings
   version: f02667b379e2fb5916c3cda2cf31e0eb885d79f8
 - name: github.com/imdario/mergo
-  version: 7fe0c75c13abdee74b09fcacef5ea1c6bba6a874
+  version: 7c29201646fa3de8506f701213473dd407f19646
 - name: github.com/jmespath/go-jmespath
   version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
+- name: github.com/Masterminds/goutils
+  version: 41ac8693c5c10a92ea1ff5ac3a7f95646f6123b0
 - name: github.com/Masterminds/semver
   version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/Masterminds/sprig
-  version: 544a9b1d90f323f6509491b389714fbbd126bee3
+  version: 9f8fceff796fb9f4e992cd2bece016be0121ab74
 - name: github.com/mattn/go-colorable
   version: efa589957cd060542a26d2dd7832fd6a6c6c3ade
 - name: github.com/mattn/go-isatty
@@ -211,7 +238,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/posener/complete
-  version: 3ef9b31a6a0613ae832e7ecf208374027c3b2343
+  version: 82e658e4f39dc2808175e6558a5315b3fa9e5e4b
   subpackages:
   - cmd
   - cmd/install
@@ -229,7 +256,7 @@ imports:
   subpackages:
   - assert
 - name: github.com/ulikunitz/xz
-  version: 590df8077fbcb06ad62d7714da06c00e5dd2316d
+  version: 6f934d456d51e742b4eeab20d925a827ef22320a
   subpackages:
   - internal/hash
   - internal/xlog
@@ -237,7 +264,7 @@ imports:
 - name: github.com/urfave/cli
   version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: github.com/zclconf/go-cty
-  version: 4ca19710f0562cab70f0b3c9cbff0ecc70ee06d1
+  version: 19dda139b164a5503de2051225fa6b94f5d39e05
   subpackages:
   - cty
   - cty/convert
@@ -246,6 +273,22 @@ imports:
   - cty/gocty
   - cty/json
   - cty/set
+- name: go.opencensus.io
+  version: 8734d3b4deb5b1369308eb92b16ca7c7dd5ff343
+  subpackages:
+  - exemplar
+  - internal
+  - internal/tagencoding
+  - plugin/ochttp
+  - plugin/ochttp/propagation/b3
+  - stats
+  - stats/internal
+  - stats/view
+  - tag
+  - trace
+  - trace/internal
+  - trace/propagation
+  - trace/tracestate
 - name: golang.org/x/crypto
   version: ff983b9c42bc9fbf91556e191cc8efb585c16908
   subpackages:
@@ -262,23 +305,102 @@ imports:
   - scrypt
   - ssh/terminal
 - name: golang.org/x/net
-  version: d26f9f9a57f3fab6a695bec0d84433c2c50f8bbf
+  version: 16b79f2e4e95ea23b2bf9903c9809ff7b013ce85
   subpackages:
+  - context
+  - context/ctxhttp
   - html
   - html/atom
+  - http/httpguts
+  - http2
+  - http2/hpack
   - idna
+  - internal/timeseries
+  - trace
+- name: golang.org/x/oauth2
+  version: e64efc72b421e893cbf63f17ba2221e7d6d0b0f3
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
   version: 48ac38b7c8cbedd50b1613c0fccacfc7d88dfcdf
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: e6919f6577db79269a6443b9dc46d18f2238fb5d
+  version: 5d731a35f4867878fc89f7744f7b6debb3beded6
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
+- name: google.golang.org/api
+  version: 1949198e2e5ae38675b60302e6e08c5cf74493fb
+  subpackages:
+  - gensupport
+  - googleapi
+  - googleapi/internal/uritemplates
+  - googleapi/transport
+  - internal
+  - iterator
+  - option
+  - storage/v1
+  - transport/http
+  - transport/http/internal/propagation
+- name: google.golang.org/appengine
+  version: 54a98f90d1c46b7731eb8fb305d2a321c30ef610
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
+- name: google.golang.org/genproto
+  version: 5fe7a883aa19554f42890211544aa549836af7b7
+  subpackages:
+  - googleapis/api/annotations
+  - googleapis/iam/v1
+  - googleapis/rpc/code
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 2369d0a0a1c8526dbd79292f41d0dbeecc8fe593
+  subpackages:
+  - balancer
+  - balancer/base
+  - balancer/roundrobin
+  - binarylog/grpc_binarylog_v1
+  - codes
+  - connectivity
+  - credentials
+  - credentials/internal
+  - encoding
+  - encoding/proto
+  - grpclog
+  - internal
+  - internal/backoff
+  - internal/binarylog
+  - internal/channelz
+  - internal/envconfig
+  - internal/grpcrand
+  - internal/grpcsync
+  - internal/syscall
+  - internal/transport
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - resolver
+  - resolver/dns
+  - resolver/passthrough
+  - stats
+  - status
+  - tap
 - name: gopkg.in/alecthomas/kingpin.v2
   version: 947dcec5ba9c011838740e680966fd7087a71d0d
 - name: gopkg.in/matryer/try.v1

--- a/options/options.go
+++ b/options/options.go
@@ -184,6 +184,18 @@ func (terragruntOptions TerragruntOptions) GetContext() (result collections.IDic
 	for key, value := range terragruntOptions.Variables {
 		result.Set(key, value.Value)
 	}
+	result.Set("TerragruntOptions", map[string]interface{}{
+		"AwsProfile":           terragruntOptions.AwsProfile,
+		"DownloadDir":          terragruntOptions.DownloadDir,
+		"LoggingLevel":         util.GetLoggingLevel(),
+		"NbWorkers":            terragruntOptions.NbWorkers,
+		"Source":               terragruntOptions.Source,
+		"SourceUpdate":         terragruntOptions.SourceUpdate,
+		"TerraformCliArgs":     terragruntOptions.TerraformCliArgs,
+		"TerraformPath":        terragruntOptions.TerraformPath,
+		"TerragruntConfigPath": terragruntOptions.TerragruntConfigPath,
+		"WorkingDir":           terragruntOptions.WorkingDir,
+	})
 	return
 }
 

--- a/util/file.go
+++ b/util/file.go
@@ -364,7 +364,7 @@ func ExpandArguments(args []interface{}, folder string) (result []interface{}) {
 		arg := fmt.Sprint(argI)
 		arg = strings.Replace(arg, `\$`, stringEscape, -1)
 		arg = strings.Replace(os.ExpandEnv(arg), stringEscape, "$", -1)
-		if strings.ContainsAny(arg, "*?[]") && !strings.ContainsAny(arg, "$|`") {
+		if strings.ContainsAny(arg, "*?[]") && !strings.ContainsAny(arg, "$|`") && !strings.HasPrefix(arg, "-") {
 			// The string contains wildcard and is not a shell command
 			if !filepath.IsAbs(arg) {
 				arg = prefix + arg

--- a/util/terraform.go
+++ b/util/terraform.go
@@ -2,12 +2,13 @@ package util
 
 import (
 	"fmt"
-	"github.com/coveo/gotemplate/yaml"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/coveo/gotemplate/yaml"
 
 	"github.com/coveo/gotemplate/collections"
 	"github.com/coveo/gotemplate/hcl"


### PR DESCRIPTION
I am fixing a problem that we faced when we tried to expose context variables from terragrunt to gotemplate.

```
pre_hook "apply-gotemplate" {
    display_name = "Apply go template"

    description = <<EOF
    Run 'gotemplate' recursively on all files with the following extensions: .template, .gt, .tf & .tfvars
    
    See https://github.com/coveo/gotemplate/blob/master/README.md for further information or
    type the following commands: 
      tgf shell
      gotemplate -h
    EOF

    command     = "gotemplate"
    expand_args = true

    arguments = [
      "--recursive",
      "--color",
      "--import=terraform.tfvars",
      "--exclude=./k8s-deployment/**,terraform.tfvars",
      "--log-level=$TERRAGRUNT_LOGGING_LEVEL",
    ]
}
```

This code was introducing a bug because terragrunt tried to expand --exclude=./k8s-deployment/**,terraform.tfvars", but that resulted to nothing.

I fix that problem and also make TerragruntOptions directly available without having to use the expand_args options.