### PR TITLE
Fix list merge function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ html-coverage:
 	@sh ./scripts/coverage.sh --html
 
 build:
-	glide install
+	go generate -x ./...
 	go build
 
 install:

--- a/config/extension_base_list.go
+++ b/config/extension_base_list.go
@@ -28,12 +28,9 @@ func (list GenericItemList) init(config *TerragruntConfigFile) {
 func (list *GenericItemList) merge(imported GenericItemList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IGenericItem(&(*list)[0]).logger().Debugf
+	log := IGenericItem(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -41,19 +38,34 @@ func (list *GenericItemList) merge(imported GenericItemList, mode mergeMode, arg
 		index[IGenericItem(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(GenericItemList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IGenericItem(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/extension_extra_args.go
+++ b/config/extension_extra_args.go
@@ -59,7 +59,7 @@ func (list TerraformExtraArgumentsList) Filter(source string) (result []string, 
 	cmd := util.IndexOrDefault(terragruntOptions.TerraformCliArgs, 0, "")
 
 	for _, arg := range list.Enabled() {
-		arg.logger().Debugf("Processing arg %s", arg.id())
+		arg.logger().Infof("Processing arg %s", arg.id())
 
 		if !util.ListContainsElement(arg.Commands, cmd) {
 			continue

--- a/config/extension_import_variables.go
+++ b/config/extension_import_variables.go
@@ -70,7 +70,7 @@ func (list ImportVariablesList) Import() (err error) {
 	variablesFiles := make(map[string]map[string]interface{})
 
 	for _, item := range list.Enabled() {
-		item.logger().Debugf("Processing import variables statement %s", item.id())
+		item.logger().Infof("Processing import variables statement %s", item.id())
 
 		if item.TFVariablesFile != "" {
 			if _, ok := variablesFiles[item.TFVariablesFile]; !ok {

--- a/config/generated_approval_config.go
+++ b/config/generated_approval_config.go
@@ -27,12 +27,9 @@ func (list ApprovalConfigList) init(config *TerragruntConfigFile) {
 func (list *ApprovalConfigList) merge(imported ApprovalConfigList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IApprovalConfig(&(*list)[0]).logger().Debugf
+	log := IApprovalConfig(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *ApprovalConfigList) merge(imported ApprovalConfigList, mode mergeMod
 		index[IApprovalConfig(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(ApprovalConfigList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IApprovalConfig(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_extra_args.go
+++ b/config/generated_extra_args.go
@@ -27,12 +27,9 @@ func (list TerraformExtraArgumentsList) init(config *TerragruntConfigFile) {
 func (list *TerraformExtraArgumentsList) merge(imported TerraformExtraArgumentsList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := ITerraformExtraArguments(&(*list)[0]).logger().Debugf
+	log := ITerraformExtraArguments(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *TerraformExtraArgumentsList) merge(imported TerraformExtraArgumentsL
 		index[ITerraformExtraArguments(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(TerraformExtraArgumentsList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := ITerraformExtraArguments(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_extra_command.go
+++ b/config/generated_extra_command.go
@@ -27,12 +27,9 @@ func (list ExtraCommandList) init(config *TerragruntConfigFile) {
 func (list *ExtraCommandList) merge(imported ExtraCommandList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IExtraCommand(&(*list)[0]).logger().Debugf
+	log := IExtraCommand(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *ExtraCommandList) merge(imported ExtraCommandList, mode mergeMode, a
 		index[IExtraCommand(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(ExtraCommandList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IExtraCommand(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_hooks.go
+++ b/config/generated_hooks.go
@@ -27,12 +27,9 @@ func (list HookList) init(config *TerragruntConfigFile) {
 func (list *HookList) merge(imported HookList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IHook(&(*list)[0]).logger().Debugf
+	log := IHook(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *HookList) merge(imported HookList, mode mergeMode, argName string) {
 		index[IHook(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(HookList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IHook(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_import_files.go
+++ b/config/generated_import_files.go
@@ -27,12 +27,9 @@ func (list ImportFilesList) init(config *TerragruntConfigFile) {
 func (list *ImportFilesList) merge(imported ImportFilesList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IImportFiles(&(*list)[0]).logger().Debugf
+	log := IImportFiles(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *ImportFilesList) merge(imported ImportFilesList, mode mergeMode, arg
 		index[IImportFiles(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(ImportFilesList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IImportFiles(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_import_variables.go
+++ b/config/generated_import_variables.go
@@ -27,12 +27,9 @@ func (list ImportVariablesList) init(config *TerragruntConfigFile) {
 func (list *ImportVariablesList) merge(imported ImportVariablesList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IImportVariables(&(*list)[0]).logger().Debugf
+	log := IImportVariables(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *ImportVariablesList) merge(imported ImportVariablesList, mode mergeM
 		index[IImportVariables(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(ImportVariablesList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IImportVariables(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -68,7 +68,7 @@ func PrintErrorWithStackTrace(err error) string {
 
 // Recover is a method that tries to recover from panics, and if it succeeds, calls the given onPanic function with an error that
 // explains the cause of the panic. This function should only be called from a defer statement.
-func Recover(onPanic func(cause error)) {
+func Recover(onPanic func(error)) {
 	if rec := recover(); rec != nil {
 		err, isError := rec.(error)
 		if !isError {


### PR DESCRIPTION
The merge function intends to override generic blocks when they are redefined in user config files.  However, there was no validation avoiding a named block to be defined more than once in a single file.

if I have a block such as:
```
import_variable "whatever" {
   ...
}

import_variable "external" {
    ...
}

import_variable "whatever" {
   ...
}
```

I understand that the second whatever block will override the content of the first one as it does if there is a block named whatever in the more context specific user files (i.e. leaves). But it is not the case when the duplicated block is defined in the same config file.

**Note that there are a lot of changed files because I changed the base file and used go generate to replicate the changes**

- Remove Glide from the makefile
- Change build step in the makefile to call go generate